### PR TITLE
feat: 按集合成视频功能 + 任务中心集成

### DIFF
--- a/ai-fusion-video-web/app/(dashboard)/projects/[id]/storyboards/page.tsx
+++ b/ai-fusion-video-web/app/(dashboard)/projects/[id]/storyboards/page.tsx
@@ -56,10 +56,9 @@ export default function StoryboardTabPage() {
   const { project } = useProject();
   const {
     addPipeline,
+    attachTaskStream,
     setPanelExpanded,
     setExpandedTaskId,
-    addSimpleTask,
-    markSimpleTask,
     setNotificationOpen,
   } = usePipelineStore();
 
@@ -114,8 +113,8 @@ export default function StoryboardTabPage() {
   // 当前选中集的合成状态
   const [currentEpisode, setCurrentEpisode] = useState<StoryboardEpisode | null>(null);
   const [composedPreviewUrl, setComposedPreviewUrl] = useState<string | null>(null);
-  // 跟踪当前活跃的合成任务在通知中心的 ID（按 episodeId 索引）
-  const composeTaskIdsRef = useRef<Map<number, string>>(new Map());
+  const [runningComposeEpisodeIds, setRunningComposeEpisodeIds] = useState<number[]>([]);
+  const [submittingComposeEpisodeIds, setSubmittingComposeEpisodeIds] = useState<number[]>([]);
 
   // 滚动定位 refs
   const sceneRefs = useRef<Record<number, HTMLDivElement | null>>({});
@@ -336,7 +335,7 @@ export default function StoryboardTabPage() {
     );
 
     // 观察所有场次元素
-    for (const [, el] of Object.entries(sceneRefs.current)) {
+    for (const el of Object.values(sceneRefs.current) as Array<HTMLDivElement | null>) {
       if (el) observer.observe(el);
     }
 
@@ -503,79 +502,62 @@ export default function StoryboardTabPage() {
     refreshCurrentEpisode();
   }, [refreshCurrentEpisode]);
 
-  // 合成中时每 2s 轮询状态
-  useEffect(() => {
-    if (currentEpisode?.composeStatus !== 1) return;
-    const id = setInterval(refreshCurrentEpisode, 2000);
-    return () => clearInterval(id);
-  }, [currentEpisode?.composeStatus, refreshCurrentEpisode]);
-
-  // 监听 episode 状态变化，把进度同步到通知中心任务
-  useEffect(() => {
-    const ep = currentEpisode;
-    if (!ep) return;
-    const taskId = composeTaskIdsRef.current.get(ep.id);
-    if (!taskId) return;
-    if (ep.composeStatus === 2) {
-      const url = ep.composedVideoUrl || "";
-      markSimpleTask(taskId, {
-        status: "done",
-        resultText: url
-          ? `✓ 合成完成 · 视频地址：${url}`
-          : "✓ 合成完成",
-      });
-      composeTaskIdsRef.current.delete(ep.id);
-      // 合成完成自动弹出视频预览
-      if (url) {
-        setComposedPreviewUrl(url);
-      }
-    } else if (ep.composeStatus === 3) {
-      markSimpleTask(taskId, {
-        status: "error",
-        errorText: ep.composeErrorMsg || "合成失败",
-      });
-      composeTaskIdsRef.current.delete(ep.id);
-    }
-  }, [
-    currentEpisode,
-    markSimpleTask,
-  ]);
-
   /** 提交本集合成视频任务 */
   const handleComposeEpisodeVideo = useCallback(async () => {
     if (!currentEpisodeId || !currentEpisode) return;
+    if (
+      submittingComposeEpisodeIds.includes(currentEpisodeId) ||
+      runningComposeEpisodeIds.includes(currentEpisodeId) ||
+      currentEpisode.composeStatus === 1
+    ) {
+      return;
+    }
+
     const epLabel = currentEpisode.title?.trim()
       || (currentEpisode.episodeNumber != null ? `第 ${currentEpisode.episodeNumber} 集` : `集 ${currentEpisode.id}`);
-    const taskId = addSimpleTask({
-      label: `合成本集视频：${epLabel}`,
-      projectId,
-      initialNote: "已提交合成任务，正在拼接镜头视频…",
-    });
-    composeTaskIdsRef.current.set(currentEpisodeId, taskId);
+    setSubmittingComposeEpisodeIds((prev) =>
+      prev.includes(currentEpisodeId) ? prev : [...prev, currentEpisodeId]
+    );
     setNotificationOpen(true);
     try {
-      await storyboardApi.composeEpisodeVideo(currentEpisodeId);
-      // 乐观切到 running，触发轮询
-      setCurrentEpisode((prev) =>
-        prev
-          ? { ...prev, composeStatus: 1, composeErrorMsg: null }
-          : prev
+      const taskId = await storyboardApi.composeEpisodeVideo(currentEpisodeId);
+      setSubmittingComposeEpisodeIds((prev) =>
+        prev.filter((id) => id !== currentEpisodeId)
       );
-      // 立即触发一次拉取（合成可能很快完成，避免等满 2s）
-      setTimeout(() => {
-        refreshCurrentEpisode();
-      }, 800);
+      setRunningComposeEpisodeIds((prev) =>
+        prev.includes(currentEpisodeId) ? prev : [...prev, currentEpisodeId]
+      );
+
+      attachTaskStream({
+        label: `合成本集视频：${epLabel}`,
+        projectId,
+        taskId,
+        cancellable: false,
+        onSettled: () => {
+          setRunningComposeEpisodeIds((prev) =>
+            prev.filter((id) => id !== currentEpisodeId)
+          );
+          void refreshCurrentEpisode();
+        },
+      });
+
+      void refreshCurrentEpisode();
     } catch (err) {
-      const msg = err instanceof Error ? err.message : "提交合成任务失败";
-      markSimpleTask(taskId, { status: "error", errorText: msg });
-      composeTaskIdsRef.current.delete(currentEpisodeId);
+      console.error("提交合成任务失败:", err);
+      setSubmittingComposeEpisodeIds((prev) =>
+        prev.filter((id) => id !== currentEpisodeId)
+      );
+      setRunningComposeEpisodeIds((prev) =>
+        prev.filter((id) => id !== currentEpisodeId)
+      );
     }
   }, [
     currentEpisodeId,
     currentEpisode,
+    submittingComposeEpisodeIds,
+    runningComposeEpisodeIds,
     projectId,
-    addSimpleTask,
-    markSimpleTask,
+    attachTaskStream,
     setNotificationOpen,
     refreshCurrentEpisode,
   ]);
@@ -743,7 +725,21 @@ export default function StoryboardTabPage() {
             {/* 合成本集视频 */}
             {currentEpisodeId && currentEpisode && (() => {
               const cs = currentEpisode.composeStatus;
-              if (cs === 1) {
+              const isSubmitting = submittingComposeEpisodeIds.includes(currentEpisodeId);
+              const isRunning = runningComposeEpisodeIds.includes(currentEpisodeId) || cs === 1;
+              if (isSubmitting) {
+                return (
+                  <button
+                    disabled
+                    className="hidden sm:flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium border border-border/30 bg-muted/20 text-muted-foreground shrink-0 cursor-not-allowed"
+                    title="正在提交合成任务"
+                  >
+                    <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                    提交中…
+                  </button>
+                );
+              }
+              if (isRunning) {
                 return (
                   <button
                     disabled

--- a/ai-fusion-video-web/app/(dashboard)/projects/[id]/storyboards/page.tsx
+++ b/ai-fusion-video-web/app/(dashboard)/projects/[id]/storyboards/page.tsx
@@ -13,6 +13,9 @@ import {
   Camera,
   Menu,
   Info,
+  Clapperboard,
+  PlayCircle,
+  AlertCircle,
 } from "lucide-react";
 import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
 import { motion } from "framer-motion";
@@ -21,6 +24,7 @@ import { scriptApi } from "@/lib/api/script";
 import {
   storyboardApi,
   type Storyboard,
+  type StoryboardEpisode,
   type StoryboardItem,
   type StoryboardScene,
 } from "@/lib/api/storyboard";
@@ -50,7 +54,14 @@ export default function StoryboardTabPage() {
   const params = useParams();
   const projectId = Number(params.id);
   const { project } = useProject();
-  const { addPipeline, setPanelExpanded, setExpandedTaskId } = usePipelineStore();
+  const {
+    addPipeline,
+    setPanelExpanded,
+    setExpandedTaskId,
+    addSimpleTask,
+    markSimpleTask,
+    setNotificationOpen,
+  } = usePipelineStore();
 
   // 分镜页始终占满 layout 宽度
   useFullWidth(true);
@@ -99,6 +110,12 @@ export default function StoryboardTabPage() {
   // 按场次分组数据
   const [sceneGroups, setSceneGroups] = useState<SceneWithItems[]>([]);
   const [loadingScenes, setLoadingScenes] = useState(false);
+
+  // 当前选中集的合成状态
+  const [currentEpisode, setCurrentEpisode] = useState<StoryboardEpisode | null>(null);
+  const [composedPreviewUrl, setComposedPreviewUrl] = useState<string | null>(null);
+  // 跟踪当前活跃的合成任务在通知中心的 ID（按 episodeId 索引）
+  const composeTaskIdsRef = useRef<Map<number, string>>(new Map());
 
   // 滚动定位 refs
   const sceneRefs = useRef<Record<number, HTMLDivElement | null>>({});
@@ -462,6 +479,107 @@ export default function StoryboardTabPage() {
     }
   };
 
+  // 当前选中的 episodeId（episode 或 scene 选择都会有）
+  const currentEpisodeId =
+    sidebarSelection.type === "episode" || sidebarSelection.type === "scene"
+      ? sidebarSelection.episodeId ?? null
+      : null;
+
+  // 拉取当前集详情（含合成状态）
+  const refreshCurrentEpisode = useCallback(async () => {
+    if (!currentEpisodeId) {
+      setCurrentEpisode(null);
+      return;
+    }
+    try {
+      const ep = await storyboardApi.getEpisode(currentEpisodeId);
+      setCurrentEpisode(ep);
+    } catch (err) {
+      console.error("加载集详情失败:", err);
+    }
+  }, [currentEpisodeId]);
+
+  useEffect(() => {
+    refreshCurrentEpisode();
+  }, [refreshCurrentEpisode]);
+
+  // 合成中时每 2s 轮询状态
+  useEffect(() => {
+    if (currentEpisode?.composeStatus !== 1) return;
+    const id = setInterval(refreshCurrentEpisode, 2000);
+    return () => clearInterval(id);
+  }, [currentEpisode?.composeStatus, refreshCurrentEpisode]);
+
+  // 监听 episode 状态变化，把进度同步到通知中心任务
+  useEffect(() => {
+    const ep = currentEpisode;
+    if (!ep) return;
+    const taskId = composeTaskIdsRef.current.get(ep.id);
+    if (!taskId) return;
+    if (ep.composeStatus === 2) {
+      const url = ep.composedVideoUrl || "";
+      markSimpleTask(taskId, {
+        status: "done",
+        resultText: url
+          ? `✓ 合成完成 · 视频地址：${url}`
+          : "✓ 合成完成",
+      });
+      composeTaskIdsRef.current.delete(ep.id);
+      // 合成完成自动弹出视频预览
+      if (url) {
+        setComposedPreviewUrl(url);
+      }
+    } else if (ep.composeStatus === 3) {
+      markSimpleTask(taskId, {
+        status: "error",
+        errorText: ep.composeErrorMsg || "合成失败",
+      });
+      composeTaskIdsRef.current.delete(ep.id);
+    }
+  }, [
+    currentEpisode,
+    markSimpleTask,
+  ]);
+
+  /** 提交本集合成视频任务 */
+  const handleComposeEpisodeVideo = useCallback(async () => {
+    if (!currentEpisodeId || !currentEpisode) return;
+    const epLabel = currentEpisode.title?.trim()
+      || (currentEpisode.episodeNumber != null ? `第 ${currentEpisode.episodeNumber} 集` : `集 ${currentEpisode.id}`);
+    const taskId = addSimpleTask({
+      label: `合成本集视频：${epLabel}`,
+      projectId,
+      initialNote: "已提交合成任务，正在拼接镜头视频…",
+    });
+    composeTaskIdsRef.current.set(currentEpisodeId, taskId);
+    setNotificationOpen(true);
+    try {
+      await storyboardApi.composeEpisodeVideo(currentEpisodeId);
+      // 乐观切到 running，触发轮询
+      setCurrentEpisode((prev) =>
+        prev
+          ? { ...prev, composeStatus: 1, composeErrorMsg: null }
+          : prev
+      );
+      // 立即触发一次拉取（合成可能很快完成，避免等满 2s）
+      setTimeout(() => {
+        refreshCurrentEpisode();
+      }, 800);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : "提交合成任务失败";
+      markSimpleTask(taskId, { status: "error", errorText: msg });
+      composeTaskIdsRef.current.delete(currentEpisodeId);
+    }
+  }, [
+    currentEpisodeId,
+    currentEpisode,
+    projectId,
+    addSimpleTask,
+    markSimpleTask,
+    setNotificationOpen,
+    refreshCurrentEpisode,
+  ]);
+
   /** 单个镜头生成视频 */
   const handleVideoGen = useCallback(
     (itemId: number) => {
@@ -622,6 +740,66 @@ export default function StoryboardTabPage() {
             </h2>
           </div>
           <div className="flex items-center gap-2">
+            {/* 合成本集视频 */}
+            {currentEpisodeId && currentEpisode && (() => {
+              const cs = currentEpisode.composeStatus;
+              if (cs === 1) {
+                return (
+                  <button
+                    disabled
+                    className="hidden sm:flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium border border-border/30 bg-muted/20 text-muted-foreground shrink-0 cursor-not-allowed"
+                    title="正在合成本集视频，预计 30s - 3min"
+                  >
+                    <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                    合成中…
+                  </button>
+                );
+              }
+              if (cs === 2 && currentEpisode.composedVideoUrl) {
+                return (
+                  <div className="hidden sm:flex items-center gap-1 shrink-0">
+                    <button
+                      onClick={() => setComposedPreviewUrl(currentEpisode.composedVideoUrl)}
+                      className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium border border-emerald-500/30 bg-emerald-500/10 text-emerald-600 hover:bg-emerald-500/20 transition-colors"
+                      title="查看本集合成视频"
+                    >
+                      <PlayCircle className="h-3.5 w-3.5" />
+                      查看本集视频
+                    </button>
+                    <button
+                      onClick={handleComposeEpisodeVideo}
+                      className="flex items-center justify-center w-8 h-8 rounded-lg border border-border/30 bg-muted/20 text-muted-foreground hover:text-foreground hover:bg-muted/40 transition-colors"
+                      title="重新合成"
+                    >
+                      <Clapperboard className="h-3.5 w-3.5" />
+                    </button>
+                  </div>
+                );
+              }
+              if (cs === 3) {
+                return (
+                  <button
+                    onClick={handleComposeEpisodeVideo}
+                    className="hidden sm:flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium border border-amber-500/30 bg-amber-500/10 text-amber-600 hover:bg-amber-500/20 transition-colors shrink-0"
+                    title={`上次失败：${currentEpisode.composeErrorMsg || "未知错误"}\n点击重试`}
+                  >
+                    <AlertCircle className="h-3.5 w-3.5" />
+                    重试合成
+                  </button>
+                );
+              }
+              return (
+                <button
+                  onClick={handleComposeEpisodeVideo}
+                  className="hidden sm:flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium border border-primary/30 bg-primary/10 text-primary hover:bg-primary/20 transition-colors shrink-0"
+                  title="将本集所有镜头视频按顺序拼接成一个完整视频"
+                >
+                  <Clapperboard className="h-3.5 w-3.5" />
+                  合成本集视频
+                </button>
+              );
+            })()}
+
             {/* 视图切换 */}
             <div className="flex items-center rounded-lg border border-border/30 bg-muted/20 p-0.5 shrink-0">
               <button
@@ -788,6 +966,47 @@ export default function StoryboardTabPage() {
         projectId={projectId}
       />
       </motion.div>
+
+      {/* 合成视频预览弹窗 */}
+      {composedPreviewUrl && (
+        <div
+          onClick={() => setComposedPreviewUrl(null)}
+          className="fixed inset-0 z-50 bg-black/80 backdrop-blur-sm flex items-center justify-center p-4"
+        >
+          <div
+            onClick={(e) => e.stopPropagation()}
+            className="relative w-full max-w-4xl rounded-xl overflow-hidden bg-card border border-border/30 shadow-xl"
+          >
+            <div className="flex items-center justify-between px-4 py-3 border-b border-border/20">
+              <h3 className="text-sm font-semibold flex items-center gap-2">
+                <PlayCircle className="h-4 w-4 text-emerald-500" />
+                本集合成视频
+              </h3>
+              <div className="flex items-center gap-2">
+                <a
+                  href={composedPreviewUrl}
+                  download
+                  className="text-xs px-3 py-1.5 rounded-lg border border-border/30 bg-muted/20 hover:bg-muted/40 transition-colors"
+                >
+                  下载
+                </a>
+                <button
+                  onClick={() => setComposedPreviewUrl(null)}
+                  className="text-xs px-3 py-1.5 rounded-lg border border-border/30 bg-muted/20 hover:bg-muted/40 transition-colors"
+                >
+                  关闭
+                </button>
+              </div>
+            </div>
+            <video
+              src={composedPreviewUrl}
+              controls
+              autoPlay
+              className="w-full max-h-[75vh] bg-black"
+            />
+          </div>
+        </div>
+      )}
     </motion.div>
   );
 }

--- a/ai-fusion-video-web/components/dashboard/notification-panel.tsx
+++ b/ai-fusion-video-web/components/dashboard/notification-panel.tsx
@@ -6,6 +6,7 @@ import {
   Loader2,
   CheckCircle2,
   XCircle,
+  Download,
   Ban,
   X,
   Trash2,
@@ -100,6 +101,95 @@ const toolDisplayNames: Record<string, string> = {
   generate_asset_image: "生成资产图片（子Agent）",
   generate_storyboard_video: "生成分镜视频（子Agent）",
 };
+
+const TASK_MEDIA_URL_LINE_REGEXP = /((?:视频地址|下载地址)[:：]\s*)(https?:\/\/[^\s)]+|\/media\/[^\s)]+)/g;
+
+interface TaskMediaLinkInfo {
+  label: string;
+  rawUrl: string;
+  resolvedUrl: string;
+}
+
+function parseTaskContent(content: string): {
+  markdownContent: string;
+  mediaLinks: TaskMediaLinkInfo[];
+} {
+  const mediaLinks: TaskMediaLinkInfo[] = [];
+  const markdownLines = content
+    .split(/\r?\n/)
+    .map((line) => {
+      let extracted = false;
+      const strippedLine = line.replace(
+        TASK_MEDIA_URL_LINE_REGEXP,
+        (_match, prefix, rawUrl) => {
+          const resolvedUrl = resolveMediaUrl(rawUrl) || rawUrl;
+          mediaLinks.push({
+            label: prefix.replace(/[:：]\s*$/, "").trim() || "下载地址",
+            rawUrl,
+            resolvedUrl,
+          });
+          extracted = true;
+          return "";
+        }
+      );
+
+      if (!extracted) {
+        return line;
+      }
+
+      return strippedLine.replace(/[·:：\s-]+$/g, "").trimEnd();
+    })
+    .filter((line) => line.trim().length > 0);
+
+  return {
+    markdownContent: markdownLines.join("\n\n"),
+    mediaLinks,
+  };
+}
+
+function TaskMediaLinks({ mediaLinks }: { mediaLinks: TaskMediaLinkInfo[] }) {
+  if (mediaLinks.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="space-y-3">
+      {mediaLinks.map((mediaLink, index) => (
+        <div
+          key={`${mediaLink.resolvedUrl}-${index}`}
+          className="rounded-xl border border-border/30 bg-muted/20 px-3 py-3"
+        >
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+            <div className="min-w-0 flex-1">
+              <p className="text-xs font-medium text-muted-foreground">
+                {mediaLink.label}
+              </p>
+              <a
+                href={mediaLink.resolvedUrl}
+                target="_blank"
+                rel="noreferrer"
+                className="mt-1 block break-all text-xs leading-relaxed text-muted-foreground underline decoration-dotted underline-offset-2 hover:text-foreground"
+                title={mediaLink.resolvedUrl}
+              >
+                {mediaLink.resolvedUrl}
+              </a>
+            </div>
+            <a
+              href={mediaLink.resolvedUrl}
+              target="_blank"
+              rel="noreferrer"
+              download
+              className="inline-flex shrink-0 items-center justify-center gap-1.5 rounded-lg border border-primary/25 bg-primary/10 px-3 py-2 text-xs font-medium text-primary transition-colors hover:bg-primary/15"
+            >
+              <Download className="h-3.5 w-3.5" />
+              下载视频
+            </a>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
 
 function getToolDisplayName(name: string) {
   return toolDisplayNames[name] || name;
@@ -241,7 +331,13 @@ function ToolItem({
           "text-destructive/80": item.status === "error",
         })}
       >
-        {item.status === "calling" ? "…" : item.status === "done" ? "✓" : "✗"}
+        {item.status === "calling" ? (
+          <Loader2 className="h-3.5 w-3.5 animate-spin" />
+        ) : item.status === "done" ? (
+          <CheckCircle2 className="h-3.5 w-3.5" />
+        ) : (
+          <AlertTriangle className="h-3.5 w-3.5" />
+        )}
       </span>
     </div>
   );
@@ -650,18 +746,23 @@ function MessageTimeline({ reasoningText, reasoningDurationMs, timeline, streami
             return null;
           }
         }
+        const { markdownContent, mediaLinks } = parseTaskContent(item.text);
         return (
-          <div key={`content-${idx}`} className="text-sm leading-relaxed">
-            <XMarkdown
-              content={item.text}
-            />
+          <div key={`content-${idx}`} className="space-y-3 text-sm leading-relaxed">
+            {markdownContent ? (
+              <XMarkdown content={markdownContent} />
+            ) : null}
+            <TaskMediaLinks mediaLinks={mediaLinks} />
           </div>
         );
       })}
 
       {/* 错误 */}
       {error && (
-        <p className="text-xs text-destructive">❌ {error}</p>
+        <div className="flex items-start gap-2 rounded-lg border border-destructive/20 bg-destructive/5 px-3 py-2 text-sm text-destructive">
+          <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+          <span className="leading-relaxed">{error}</span>
+        </div>
       )}
     </>
   );
@@ -673,6 +774,7 @@ function PipelineDetailPanel({ task }: { task: PipelineTask }) {
   const [idleTimelineLength, setIdleTimelineLength] = useState<number | null>(null);
   const timelineLength = task.state.timeline.length;
   const isIdle = task.status === "running" && idleTimelineLength === timelineLength;
+  const canCancel = task.status === "running" && task.cancellable !== false;
 
   // 外层智能自动滚动（用户上滚打断，滚回底部恢复）
   const timelineRef = useSmartScroll(
@@ -721,7 +823,7 @@ function PipelineDetailPanel({ task }: { task: PipelineTask }) {
             </span>
           </p>
         </div>
-        {task.status === "running" && (
+        {canCancel && (
           <button
             onClick={() => usePipelineStore.getState().cancelPipeline(task.id)}
             className={cn(
@@ -783,6 +885,7 @@ const agentTypeNames: Record<string, string> = {
   asset_image_executor: "资产图片执行",
   storyboard_video_gen: "分镜视频生成",
   storyboard_video_executor: "分镜视频执行",
+  storyboard_episode_compose: "分集合成视频",
   script_assistant: "剧本助手",
   ai_media: "默认助手",
   concept_visualizer: "概念可视化",
@@ -1880,7 +1983,11 @@ function pushReasoningToTimeline(
 function pushContentToTimeline(timeline: TimelineItem[], text: string) {
   const last = timeline[timeline.length - 1];
   if (last && last.type === "content") {
-    last.text += text;
+    last.text = last.text.endsWith("\n\n")
+      ? last.text + text
+      : last.text.endsWith("\n")
+        ? `${last.text}\n${text}`
+        : `${last.text}\n\n${text}`;
     return;
   }
   timeline.push({ type: "content", text });
@@ -1922,7 +2029,11 @@ function pushReasoningToSubTimeline(
 function pushContentToSubTimeline(children: SubTimelineItem[], text: string) {
   const last = children[children.length - 1];
   if (last && last.type === "content") {
-    last.text += text;
+    last.text = last.text.endsWith("\n\n")
+      ? last.text + text
+      : last.text.endsWith("\n")
+        ? `${last.text}\n${text}`
+        : `${last.text}\n\n${text}`;
     return;
   }
   children.push({ type: "content", text });
@@ -2086,6 +2197,28 @@ function messagesToTimeline(messages: AgentMessage[]): MessageTimelineProps["tim
   return timeline;
 }
 
+function resolveHistoryErrorMessage(
+  conversation: AgentConversation,
+  messages: AgentMessage[]
+): string | undefined {
+  const isErrorConversation =
+    conversation.status === "error" || conversation.status === "failed";
+  if (!isErrorConversation) {
+    return undefined;
+  }
+
+  for (let index = messages.length - 1; index >= 0; index--) {
+    const message = messages[index];
+    const content = message.content?.trim();
+    if (!content || message.role === "user") {
+      continue;
+    }
+    return content;
+  }
+
+  return "任务执行失败";
+}
+
 // ========== 历史消息详情面板（右侧） ==========
 
 function HistoryDetailPanel({
@@ -2130,6 +2263,7 @@ function HistoryDetailPanel({
 
   // Pipeline 类型：过滤掉用户消息（根据 category 或 agentType 判断）
   const isPipeline =
+    conversation.category === "task" ||
     conversation.category === "pipeline" ||
     (conversation.agentType != null &&
       (PIPELINE_AGENT_TYPES as readonly string[]).includes(conversation.agentType));
@@ -2144,6 +2278,7 @@ function HistoryDetailPanel({
 
   // 转换为统一时间线格式
   const timeline = messagesToTimeline(displayMessages);
+  const historyError = resolveHistoryErrorMessage(conversation, displayMessages);
 
   return (
     <div className="flex flex-col h-full">
@@ -2188,6 +2323,7 @@ function HistoryDetailPanel({
             reasoningDurationMs={firstAssistant?.reasoningDurationMs || undefined}
             timeline={timeline}
             streaming={false}
+            error={historyError}
           />
         )}
       </div>
@@ -2219,6 +2355,7 @@ function PipelineTaskCard({ task }: { task: PipelineTask }) {
 
   const getLatestActivity = (): string => {
     const timeline = task.state.timeline;
+    const isTaskStream = task.cancellable === false;
     for (let i = timeline.length - 1; i >= 0; i--) {
       const item = timeline[i];
       if (item.type === "reasoning") {
@@ -2227,14 +2364,17 @@ function PipelineTaskCard({ task }: { task: PipelineTask }) {
       if (item.type === "tool") {
         return item.status === "calling"
           ? `正在${getToolDisplayName(item.name)}…`
-          : `${getToolDisplayName(item.name)} ✓`;
+          : `${getToolDisplayName(item.name)} 已完成`;
       }
       if (item.type === "content") {
+        if (isTaskStream) {
+          return task.status === "running" ? "任务执行中…" : "已记录任务结果";
+        }
         return task.status === "running" ? "AI 正在输出…" : "已生成回复";
       }
     }
     if (task.state.reasoningText) return "AI 正在思考…";
-    return "准备中…";
+    return isTaskStream ? "任务准备中…" : "准备中…";
   };
 
   const handleOpenDetail = () => {

--- a/ai-fusion-video-web/lib/api/storyboard.ts
+++ b/ai-fusion-video-web/lib/api/storyboard.ts
@@ -238,7 +238,7 @@ export const storyboardApi = {
 
   /** 提交本集合成视频任务（异步） */
   composeEpisodeVideo: (episodeId: number) =>
-    http.post<never, boolean>(`/api/storyboard/episode/${episodeId}/compose-video`),
+    http.post<never, string>(`/api/storyboard/episode/${episodeId}/compose-video`),
 
   // ========== 分镜场次 ==========
 

--- a/ai-fusion-video-web/lib/api/storyboard.ts
+++ b/ai-fusion-video-web/lib/api/storyboard.ts
@@ -19,6 +19,9 @@ export interface Storyboard {
   updateTime: string;
 }
 
+/** 分镜集合成状态: 0未开始 1合成中 2已完成 3失败 */
+export type EpisodeComposeStatus = 0 | 1 | 2 | 3;
+
 /** 分镜集 */
 export interface StoryboardEpisode {
   id: number;
@@ -28,6 +31,10 @@ export interface StoryboardEpisode {
   synopsis: string | null;
   sortOrder: number;
   status: number;
+  composedVideoUrl: string | null;
+  composeStatus: EpisodeComposeStatus;
+  composeErrorMsg: string | null;
+  composedAt: string | null;
   createTime: string;
   updateTime: string;
 }
@@ -228,6 +235,10 @@ export const storyboardApi = {
   /** 删除分镜集 */
   deleteEpisode: (id: number) =>
     http.delete<never, boolean>(`/api/storyboard/episode/${id}`),
+
+  /** 提交本集合成视频任务（异步） */
+  composeEpisodeVideo: (episodeId: number) =>
+    http.post<never, boolean>(`/api/storyboard/episode/${episodeId}/compose-video`),
 
   // ========== 分镜场次 ==========
 

--- a/ai-fusion-video-web/lib/api/task-stream.ts
+++ b/ai-fusion-video-web/lib/api/task-stream.ts
@@ -1,0 +1,108 @@
+import { API_BASE_URL, http } from "./client";
+import type { AgentConversation } from "./ai-assistant";
+import {
+  authenticatedFetch,
+  type AiChatStreamEvent,
+  type StreamCallbacks,
+} from "./ai-assistant";
+
+export type { AiChatStreamEvent, StreamCallbacks };
+
+function parseSseEventBlock(eventBlock: string, callbacks: StreamCallbacks) {
+  const dataLines: string[] = [];
+
+  for (const rawLine of eventBlock.split("\n")) {
+    const line = rawLine.trimEnd();
+    if (!line || line.startsWith(":")) {
+      continue;
+    }
+    if (line.startsWith("data:")) {
+      dataLines.push(line.slice(5).trimStart());
+    }
+  }
+
+  const jsonStr = dataLines.join("\n").trim();
+  if (!jsonStr) {
+    return;
+  }
+
+  try {
+    const event: AiChatStreamEvent = JSON.parse(jsonStr);
+    callbacks.onEvent(event);
+  } catch {
+    console.warn("Task SSE 解析失败:", jsonStr);
+  }
+}
+
+function consumeSseBuffer(buffer: string, callbacks: StreamCallbacks) {
+  const normalizedBuffer = buffer.replace(/\r\n/g, "\n");
+  const eventBlocks = normalizedBuffer.split("\n\n");
+  const remaining = eventBlocks.pop() || "";
+
+  for (const eventBlock of eventBlocks) {
+    parseSseEventBlock(eventBlock, callbacks);
+  }
+
+  return remaining;
+}
+
+export function reconnectTaskStream(
+  taskId: string,
+  callbacks: StreamCallbacks
+): AbortController {
+  const controller = new AbortController();
+
+  (async () => {
+    try {
+      const response = await authenticatedFetch(
+        `${API_BASE_URL}/api/task-stream/reconnect?taskId=${encodeURIComponent(taskId)}`,
+        {
+          signal: controller.signal,
+        }
+      );
+
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+      }
+
+      const reader = response.body?.getReader();
+      if (!reader) {
+        throw new Error("无法获取响应流");
+      }
+
+      const decoder = new TextDecoder();
+      let buffer = "";
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+        buffer = consumeSseBuffer(buffer, callbacks);
+      }
+
+      if (buffer.trim()) {
+        parseSseEventBlock(buffer, callbacks);
+      }
+
+      callbacks.onComplete?.();
+    } catch (err) {
+      if (err instanceof DOMException && err.name === "AbortError") {
+        return;
+      }
+      callbacks.onError?.(err instanceof Error ? err : new Error(String(err)));
+    }
+  })();
+
+  return controller;
+}
+
+export async function getTaskStreamStatus(taskId: string): Promise<string> {
+  return http.get(
+    `/api/task-stream/status?taskId=${encodeURIComponent(taskId)}`
+  );
+}
+
+export async function listRunningTaskStreams(): Promise<AgentConversation[]> {
+  return http.get("/api/task-stream/running");
+}

--- a/ai-fusion-video-web/lib/store/pipeline-store.ts
+++ b/ai-fusion-video-web/lib/store/pipeline-store.ts
@@ -4,12 +4,14 @@ import { create } from "zustand";
 import {
   pipelineStream,
   cancelPipeline,
-  reconnectPipelineStream,
-  getPipelineStatus,
-  listRunningPipelines,
   type AiChatReq,
   type AiChatStreamEvent,
 } from "@/lib/api/ai-pipeline";
+import {
+  reconnectTaskStream,
+  getTaskStreamStatus,
+  listRunningTaskStreams,
+} from "@/lib/api/task-stream";
 
 // ========== 数据失效映射 ==========
 
@@ -80,6 +82,7 @@ export interface PipelineTask {
   status: "running" | "done" | "error" | "cancelled";
   state: PipelineState;
   createdAt: number;
+  cancellable?: boolean;
   /** 任务结束时间（done/error/cancelled 时记录） */
   finishedAt?: number;
 }
@@ -104,6 +107,14 @@ interface PipelineStoreState {
     projectId: number;
     request: AiChatReq;
     onComplete?: () => void;
+  }) => string;
+  attachTaskStream: (config: {
+    label: string;
+    projectId: number;
+    taskId: string;
+    cancellable?: boolean;
+    onComplete?: () => void;
+    onSettled?: (status: "done" | "error" | "cancelled") => void;
   }) => string;
   /**
    * 添加一个非 AI 任务（如视频合成），不走 SSE 流。
@@ -151,6 +162,27 @@ function isMainAgentTerminalEvent(event: AiChatStreamEvent): boolean {
 let idCounter = 0;
 function generateId(): string {
   return `pipeline-${Date.now()}-${++idCounter}`;
+}
+
+type ContentMergeMode = "stream" | "paragraph";
+
+function mergeContentText(
+  existingText: string,
+  incomingText: string,
+  mode: ContentMergeMode
+): string {
+  if (!existingText) return incomingText;
+  if (!incomingText) return existingText;
+  if (mode === "stream") {
+    return existingText + incomingText;
+  }
+  if (existingText.endsWith("\n\n")) {
+    return existingText + incomingText;
+  }
+  if (existingText.endsWith("\n")) {
+    return `${existingText}\n${incomingText}`;
+  }
+  return `${existingText}\n\n${incomingText}`;
 }
 
 /**
@@ -296,7 +328,9 @@ function updateLastTimelineReasoningDuration(
 function createEventHandler(
   id: string,
   set: (fn: (s: PipelineStoreState) => Partial<PipelineStoreState>) => void,
-  onComplete?: () => void
+  onComplete?: () => void,
+  onSettled?: (status: "done" | "error" | "cancelled") => void,
+  contentMergeMode: ContentMergeMode = "stream"
 ) {
   // 事件队列 + rAF 节流，避免高频 set() 导致 Maximum update depth exceeded
   const eventQueue: AiChatStreamEvent[] = [];
@@ -358,6 +392,7 @@ function createEventHandler(
                 );
               }
               if (event.content) {
+                const content = event.content;
                 if (isSubAgent) {
                   next.timeline = appendToToolChildren(
                     next.timeline,
@@ -376,12 +411,19 @@ function createEventHandler(
                       if (last && last.type === "content") {
                         return [
                           ...updatedChildren.slice(0, -1),
-                          { ...last, text: last.text + event.content },
+                          {
+                            ...last,
+                            text: mergeContentText(
+                              last.text,
+                              content,
+                              contentMergeMode
+                            ),
+                          },
                         ];
                       }
                       return [
                         ...updatedChildren,
-                        { type: "content" as const, text: event.content! },
+                        { type: "content" as const, text: content },
                       ];
                     }
                   );
@@ -390,12 +432,16 @@ function createEventHandler(
                   if (last && last.type === "content") {
                     next.timeline[next.timeline.length - 1] = {
                       ...last,
-                      text: last.text + event.content,
+                      text: mergeContentText(
+                        last.text,
+                        content,
+                        contentMergeMode
+                      ),
                     };
                   } else {
                     next.timeline.push({
                       type: "content",
-                      text: event.content,
+                      text: content,
                     });
                   }
                 }
@@ -524,7 +570,11 @@ function createEventHandler(
                 if (last && last.type === "content") {
                   next.timeline[next.timeline.length - 1] = {
                     ...last,
-                    text: last.text + event.content,
+                    text: mergeContentText(
+                      last.text,
+                      event.content,
+                      contentMergeMode
+                    ),
                   };
                 } else {
                   next.timeline.push({ type: "content", text: event.content });
@@ -546,14 +596,14 @@ function createEventHandler(
                     ...children,
                     {
                       type: "content" as const,
-                      text: `❌ ${event.agentName || "子Agent"} 出错: ${event.error || "未知错误"}`,
+                        text: `${event.agentName || "子Agent"} 出错：${event.error || "未知错误"}`,
                     },
                   ]
                 );
               } else if (event.agentName) {
                 next.timeline.push({
                   type: "content",
-                  text: `❌ ${event.agentName} 出错: ${event.error || "未知错误"}`,
+                  text: `${event.agentName} 出错：${event.error || "未知错误"}`,
                 });
               } else {
                 next.status = "error";
@@ -601,12 +651,16 @@ function createEventHandler(
       if (event.outputType === "DONE" && isMainAgentTerminalEvent(event)) {
         abortControllers.delete(id);
         onComplete?.();
+        onSettled?.("done");
       }
       if (
         (event.outputType === "ERROR" || event.outputType === "CANCELLED") &&
         isMainAgentTerminalEvent(event)
       ) {
         abortControllers.delete(id);
+        onSettled?.(
+          event.outputType === "CANCELLED" ? "cancelled" : "error"
+        );
       }
     }
   }
@@ -622,6 +676,46 @@ function createEventHandler(
       }
     }
   };
+}
+
+function settleTaskIfRunning(
+  set: (fn: (s: PipelineStoreState) => Partial<PipelineStoreState>) => void,
+  id: string,
+  status: "done" | "error" | "cancelled",
+  options?: {
+    error?: string;
+    onComplete?: () => void;
+    onSettled?: (status: "done" | "error" | "cancelled") => void;
+  }
+) {
+  let transitioned = false;
+  set((s) => ({
+    tasks: s.tasks.map((t) => {
+      if (t.id !== id || t.status !== "running") {
+        return t;
+      }
+      transitioned = true;
+      return {
+        ...t,
+        status,
+        finishedAt: Date.now(),
+        state: {
+          ...t.state,
+          status,
+          ...(status === "error"
+            ? { error: options?.error || t.state.error || "任务失败" }
+            : {}),
+        },
+      };
+    }),
+  }));
+  abortControllers.delete(id);
+  if (transitioned) {
+    if (status === "done") {
+      options?.onComplete?.();
+    }
+    options?.onSettled?.(status);
+  }
 }
 
 export const usePipelineStore = create<PipelineStoreState>()((set, get) => ({
@@ -646,6 +740,7 @@ export const usePipelineStore = create<PipelineStoreState>()((set, get) => ({
       status: "running",
       state: initialState,
       createdAt: Date.now(),
+      cancellable: false,
     };
     set((s) => ({ tasks: [...s.tasks, task] }));
     if (onComplete) {
@@ -706,6 +801,7 @@ export const usePipelineStore = create<PipelineStoreState>()((set, get) => ({
       status: "running",
       state: initialState,
       createdAt: Date.now(),
+      cancellable: true,
     };
 
     set((s) => ({ tasks: [...s.tasks, task] }));
@@ -759,6 +855,93 @@ export const usePipelineStore = create<PipelineStoreState>()((set, get) => ({
     return id;
   },
 
+  attachTaskStream: ({
+    label,
+    projectId,
+    taskId,
+    cancellable = false,
+    onComplete,
+    onSettled,
+  }) => {
+    const id = generateId();
+    const task: PipelineTask = {
+      id,
+      label,
+      projectId,
+      status: "running",
+      state: {
+        status: "running",
+        reasoningText: "",
+        timeline: [{ type: "content", text: "正在连接任务流……" }],
+        conversationId: taskId,
+      },
+      createdAt: Date.now(),
+      cancellable,
+    };
+
+    set((s) => ({ tasks: [...s.tasks, task] }));
+
+    void (async () => {
+      try {
+        const streamStatus = await getTaskStreamStatus(taskId);
+        if (streamStatus === "NONE") {
+          settleTaskIfRunning(set, id, "error", {
+            error: "任务流不存在",
+            onSettled,
+          });
+          return;
+        }
+
+        const handleEvent = createEventHandler(
+          id,
+          set,
+          onComplete,
+          onSettled,
+          "paragraph"
+        );
+
+        set((s) => ({
+          tasks: s.tasks.map((t) =>
+            t.id === id
+              ? { ...t, state: { ...t.state, timeline: [] } }
+              : t
+          ),
+        }));
+
+        const controller = reconnectTaskStream(taskId, {
+          onEvent: handleEvent,
+          onError: (err) => {
+            settleTaskIfRunning(set, id, "error", {
+              error: err.message,
+              onSettled,
+            });
+          },
+          onComplete: () => {
+            const fallbackStatus =
+              streamStatus === "ERROR"
+                ? "error"
+                : streamStatus === "COMPLETED"
+                  ? "done"
+                  : "done";
+            settleTaskIfRunning(set, id, fallbackStatus, {
+              onComplete,
+              onSettled,
+            });
+          },
+        });
+
+        abortControllers.set(id, controller);
+      } catch (err) {
+        settleTaskIfRunning(set, id, "error", {
+          error: err instanceof Error ? err.message : "连接任务流失败",
+          onSettled,
+        });
+      }
+    })();
+
+    return id;
+  },
+
   cancelPipeline: async (id: string) => {
     const task = get().tasks.find((t) => t.id === id);
     const controller = abortControllers.get(id);
@@ -792,6 +975,7 @@ export const usePipelineStore = create<PipelineStoreState>()((set, get) => ({
   removePipeline: (id: string) => {
     abortControllers.get(id)?.abort();
     abortControllers.delete(id);
+    simpleTaskCallbacks.delete(id);
     set((s) => ({
       tasks: s.tasks.filter((t) => t.id !== id),
       expandedTaskId: s.expandedTaskId === id ? null : s.expandedTaskId,
@@ -799,6 +983,13 @@ export const usePipelineStore = create<PipelineStoreState>()((set, get) => ({
   },
 
   clearCompleted: () => {
+    const removableIds = get().tasks
+      .filter((t) => t.status !== "running")
+      .map((t) => t.id);
+    for (const id of removableIds) {
+      abortControllers.delete(id);
+      simpleTaskCallbacks.delete(id);
+    }
     set((s) => ({
       tasks: s.tasks.filter((t) => t.status === "running"),
       expandedTaskId:
@@ -835,7 +1026,7 @@ export const usePipelineStore = create<PipelineStoreState>()((set, get) => ({
     // 异步查询后端
     (async () => {
       try {
-        const runningConvs = await listRunningPipelines();
+        const runningConvs = await listRunningTaskStreams();
         if (runningConvs.length === 0) {
           console.log("[Pipeline] 无运行中任务");
           return;
@@ -870,20 +1061,27 @@ export const usePipelineStore = create<PipelineStoreState>()((set, get) => ({
             createdAt: conv.createTime
               ? new Date(conv.createTime).getTime()
               : Date.now(),
+            cancellable: conv.category !== "task",
           };
 
           set((s) => ({ tasks: [...s.tasks, placeholder] }));
 
           // 检查 Redis 流状态
           try {
-            const streamStatus = await getPipelineStatus(conversationId);
+            const streamStatus = await getTaskStreamStatus(conversationId);
             console.log(
               `[Pipeline] 对话 ${conversationId} Redis 状态: ${streamStatus}`
             );
 
             if (streamStatus === "ACTIVE") {
               // 后台仍在运行 → 重连 SSE
-              const handleEvent = createEventHandler(id, set);
+              const handleEvent = createEventHandler(
+                id,
+                set,
+                undefined,
+                undefined,
+                conv.category === "task" ? "paragraph" : "stream"
+              );
 
               // 清空占位文本
               set((s) => ({
@@ -894,39 +1092,13 @@ export const usePipelineStore = create<PipelineStoreState>()((set, get) => ({
                 ),
               }));
 
-              const controller = reconnectPipelineStream(conversationId, {
+              const controller = reconnectTaskStream(conversationId, {
                 onEvent: handleEvent,
                 onError: (err) => {
-                  set((s) => ({
-                    tasks: s.tasks.map((t) =>
-                      t.id === id
-                        ? {
-                            ...t,
-                            status: "error" as const,
-                            state: {
-                              ...t.state,
-                              status: "error" as const,
-                              error: err.message,
-                            },
-                          }
-                        : t
-                    ),
-                  }));
-                  abortControllers.delete(id);
+                  settleTaskIfRunning(set, id, "error", { error: err.message });
                 },
                 onComplete: () => {
-                  set((s) => ({
-                    tasks: s.tasks.map((t) =>
-                      t.id === id && t.status === "running"
-                        ? {
-                            ...t,
-                            status: "done" as const,
-                            state: { ...t.state, status: "done" as const },
-                          }
-                        : t
-                    ),
-                  }));
-                  abortControllers.delete(id);
+                  settleTaskIfRunning(set, id, "done");
                 },
               });
 

--- a/ai-fusion-video-web/lib/store/pipeline-store.ts
+++ b/ai-fusion-video-web/lib/store/pipeline-store.ts
@@ -105,6 +105,25 @@ interface PipelineStoreState {
     request: AiChatReq;
     onComplete?: () => void;
   }) => string;
+  /**
+   * 添加一个非 AI 任务（如视频合成），不走 SSE 流。
+   * 调用方负责后续通过 markSimpleTask 推进状态。
+   */
+  addSimpleTask: (config: {
+    label: string;
+    projectId: number;
+    initialNote?: string;
+    onComplete?: () => void;
+  }) => string;
+  /** 推进非 AI 任务的状态（追加结果文本/错误，标记完成或失败） */
+  markSimpleTask: (
+    id: string,
+    update: {
+      status: "done" | "error";
+      resultText?: string;
+      errorText?: string;
+    }
+  ) => void;
   cancelPipeline: (id: string) => void;
   removePipeline: (id: string) => void;
   clearCompleted: () => void;
@@ -114,6 +133,9 @@ interface PipelineStoreState {
   /** 页面加载时调用：查询后端 running 对话并尝试 SSE 重连 */
   tryReconnect: () => void;
 }
+
+// 简单任务的完成回调（不放在 zustand state 里避免序列化问题）
+const simpleTaskCallbacks = new Map<string, () => void>();
 
 // 存储 AbortController 的 map（不放在 zustand state 里避免序列化问题）
 const abortControllers = new Map<string, AbortController>();
@@ -609,6 +631,65 @@ export const usePipelineStore = create<PipelineStoreState>()((set, get) => ({
   expandedTaskId: null,
   reconnected: false,
   invalidation: { assets: 0, scripts: 0, storyboards: 0 },
+
+  addSimpleTask: ({ label, projectId, initialNote, onComplete }) => {
+    const id = generateId();
+    const initialState: PipelineState = {
+      status: "running",
+      reasoningText: "",
+      timeline: initialNote ? [{ type: "content", text: initialNote }] : [],
+    };
+    const task: PipelineTask = {
+      id,
+      label,
+      projectId,
+      status: "running",
+      state: initialState,
+      createdAt: Date.now(),
+    };
+    set((s) => ({ tasks: [...s.tasks, task] }));
+    if (onComplete) {
+      simpleTaskCallbacks.set(id, onComplete);
+    }
+    return id;
+  },
+
+  markSimpleTask: (id, update) => {
+    set((s) => ({
+      tasks: s.tasks.map((t) => {
+        if (t.id !== id) return t;
+        const isFinishingFromRunning = t.status === "running";
+        const newTimeline = [...t.state.timeline];
+        if (update.resultText) {
+          newTimeline.push({ type: "content", text: update.resultText });
+        }
+        return {
+          ...t,
+          status: update.status,
+          state: {
+            ...t.state,
+            status: update.status,
+            timeline: newTimeline,
+            error: update.errorText,
+          },
+          ...(isFinishingFromRunning ? { finishedAt: Date.now() } : {}),
+        };
+      }),
+    }));
+    if (update.status === "done") {
+      const cb = simpleTaskCallbacks.get(id);
+      if (cb) {
+        try {
+          cb();
+        } catch (e) {
+          console.error("[simpleTask] onComplete error", e);
+        }
+        simpleTaskCallbacks.delete(id);
+      }
+    } else {
+      simpleTaskCallbacks.delete(id);
+    }
+  },
 
   addPipeline: ({ label, projectId, request, onComplete }) => {
     const id = generateId();

--- a/ai-fusion-video-web/package.json
+++ b/ai-fusion-video-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-fusion-video-web",
-  "version": "0.4.3",
+  "version": "0.5.0",
   "private": true,
   "description": "Web application for the AI-driven video creation platform",
   "license": "MIT",

--- a/ai-fusion-video/Dockerfile
+++ b/ai-fusion-video/Dockerfile
@@ -25,6 +25,10 @@ LABEL maintainer="Stonewu <https://github.com/Stonewuu>"
 
 WORKDIR /app
 
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends ffmpeg curl \
+  && rm -rf /var/lib/apt/lists/*
+
 # 从构建阶段复制 JAR
 COPY --from=builder /build/target/*.jar app.jar
 

--- a/ai-fusion-video/docker-build/Dockerfile
+++ b/ai-fusion-video/docker-build/Dockerfile
@@ -4,6 +4,10 @@ LABEL maintainer="Stonewu <https://github.com/Stonewuu>"
 
 WORKDIR /app
 
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends ffmpeg curl \
+  && rm -rf /var/lib/apt/lists/*
+
 COPY app.jar app.jar
 
 RUN mkdir -p /app/data/media

--- a/ai-fusion-video/src/main/java/com/stonewu/fusion/config/AsyncConfig.java
+++ b/ai-fusion-video/src/main/java/com/stonewu/fusion/config/AsyncConfig.java
@@ -1,0 +1,29 @@
+package com.stonewu.fusion.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+/**
+ * 异步任务配置 - 启用 @Async 支持，并定义视频合成专用线程池。
+ */
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+
+    @Bean(name = "videoComposeExecutor")
+    public Executor videoComposeExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(1);
+        executor.setMaxPoolSize(2);
+        executor.setQueueCapacity(20);
+        executor.setThreadNamePrefix("video-compose-");
+        executor.setWaitForTasksToCompleteOnShutdown(true);
+        executor.setAwaitTerminationSeconds(60);
+        executor.initialize();
+        return executor;
+    }
+}

--- a/ai-fusion-video/src/main/java/com/stonewu/fusion/controller/storyboard/StoryboardController.java
+++ b/ai-fusion-video/src/main/java/com/stonewu/fusion/controller/storyboard/StoryboardController.java
@@ -25,6 +25,8 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+import static com.stonewu.fusion.security.SecurityUtils.requireCurrentUserId;
+
 /**
  * 分镜脚本 Controller
  */
@@ -109,9 +111,9 @@ public class StoryboardController {
 
     @Operation(summary = "提交本集合成视频任务（异步）")
     @PostMapping("/episode/{id}/compose-video")
-    public CommonResult<Boolean> composeEpisodeVideo(@PathVariable Long id) {
-        videoComposeService.submitCompose(id);
-        return CommonResult.success(true);
+    public CommonResult<String> composeEpisodeVideo(@PathVariable Long id) {
+        Long userId = requireCurrentUserId();
+        return CommonResult.success(videoComposeService.submitCompose(id, userId));
     }
 
     // ========== 分镜场次 ==========

--- a/ai-fusion-video/src/main/java/com/stonewu/fusion/controller/storyboard/StoryboardController.java
+++ b/ai-fusion-video/src/main/java/com/stonewu/fusion/controller/storyboard/StoryboardController.java
@@ -16,6 +16,7 @@ import com.stonewu.fusion.entity.storyboard.StoryboardEpisode;
 import com.stonewu.fusion.entity.storyboard.StoryboardItem;
 import com.stonewu.fusion.entity.storyboard.StoryboardScene;
 import com.stonewu.fusion.service.storyboard.StoryboardService;
+import com.stonewu.fusion.service.storyboard.VideoComposeService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -34,6 +35,7 @@ import java.util.List;
 public class StoryboardController {
 
     private final StoryboardService storyboardService;
+    private final VideoComposeService videoComposeService;
 
     // ========== 分镜脚本 ==========
 
@@ -102,6 +104,13 @@ public class StoryboardController {
     @DeleteMapping("/episode/{id}")
     public CommonResult<Boolean> deleteEpisode(@PathVariable Long id) {
         storyboardService.deleteEpisode(id);
+        return CommonResult.success(true);
+    }
+
+    @Operation(summary = "提交本集合成视频任务（异步）")
+    @PostMapping("/episode/{id}/compose-video")
+    public CommonResult<Boolean> composeEpisodeVideo(@PathVariable Long id) {
+        videoComposeService.submitCompose(id);
         return CommonResult.success(true);
     }
 

--- a/ai-fusion-video/src/main/java/com/stonewu/fusion/controller/task/TaskStreamController.java
+++ b/ai-fusion-video/src/main/java/com/stonewu/fusion/controller/task/TaskStreamController.java
@@ -1,0 +1,50 @@
+package com.stonewu.fusion.controller.task;
+
+import com.stonewu.fusion.common.CommonResult;
+import com.stonewu.fusion.controller.ai.vo.AiChatStreamRespVO;
+import com.stonewu.fusion.entity.ai.AgentConversation;
+import com.stonewu.fusion.service.task.TaskStreamService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Flux;
+
+import java.util.List;
+
+import static com.stonewu.fusion.security.SecurityUtils.requireCurrentUserId;
+
+/**
+ * 通用任务流 Controller。
+ */
+@Tag(name = "任务流")
+@RestController
+@RequestMapping("/api/task-stream")
+@RequiredArgsConstructor
+public class TaskStreamController {
+
+    private final TaskStreamService taskStreamService;
+
+    @Operation(summary = "重连任务流（页面刷新后恢复 SSE）")
+    @GetMapping(value = "/reconnect", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public Flux<AiChatStreamRespVO> reconnect(@RequestParam String taskId) {
+        return taskStreamService.reconnect(taskId);
+    }
+
+    @Operation(summary = "查询任务流状态")
+    @GetMapping("/status")
+    public CommonResult<String> getStatus(@RequestParam String taskId) {
+        return CommonResult.success(taskStreamService.getStatus(taskId));
+    }
+
+    @Operation(summary = "查询运行中的任务流列表")
+    @GetMapping("/running")
+    public CommonResult<List<AgentConversation>> listRunning() {
+        Long userId = requireCurrentUserId();
+        return CommonResult.success(taskStreamService.listRunning(userId));
+    }
+}

--- a/ai-fusion-video/src/main/java/com/stonewu/fusion/entity/storyboard/StoryboardEpisode.java
+++ b/ai-fusion-video/src/main/java/com/stonewu/fusion/entity/storyboard/StoryboardEpisode.java
@@ -6,6 +6,8 @@ import com.baomidou.mybatisplus.annotation.TableName;
 import com.stonewu.fusion.common.BaseEntity;
 import lombok.*;
 
+import java.time.LocalDateTime;
+
 /**
  * 分镜集实体
  * <p>
@@ -44,4 +46,17 @@ public class StoryboardEpisode extends BaseEntity {
     /** 状态：0-草稿 1-正常 */
     @Builder.Default
     private Integer status = 0;
+
+    /** 本集合成视频URL */
+    private String composedVideoUrl;
+
+    /** 合成状态: 0未开始 1合成中 2已完成 3失败 */
+    @Builder.Default
+    private Integer composeStatus = 0;
+
+    /** 合成失败原因 */
+    private String composeErrorMsg;
+
+    /** 合成完成时间 */
+    private LocalDateTime composedAt;
 }

--- a/ai-fusion-video/src/main/java/com/stonewu/fusion/service/storage/MediaStorageService.java
+++ b/ai-fusion-video/src/main/java/com/stonewu/fusion/service/storage/MediaStorageService.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -73,6 +74,23 @@ public class MediaStorageService {
         log.info("[MediaStorage] 直接保存字节: size={}, subDir={}, ext={}, strategy={}",
                 data.length, subDir, extension, strategy.getType());
         return strategy.storeBytes(data, subDir, extension, config);
+    }
+
+    /**
+     * 从本地文件保存到默认存储后端
+     *
+     * @param filePath   本地文件路径
+     * @param subDir     子目录
+     * @param extension  文件扩展名
+     * @return 持久化后的可访问 URL
+     */
+    public String storeFile(Path filePath, String subDir, String extension) {
+        StorageConfig config = storageConfigService.getDefaultConfig();
+        StorageStrategy strategy = resolveStrategy(config);
+
+        log.info("[MediaStorage] 直接保存文件: path={}, subDir={}, ext={}, strategy={}",
+                filePath, subDir, extension, strategy.getType());
+        return strategy.storeFile(filePath, subDir, extension, config);
     }
 
     private StorageStrategy resolveStrategy(StorageConfig config) {

--- a/ai-fusion-video/src/main/java/com/stonewu/fusion/service/storage/StorageStrategy.java
+++ b/ai-fusion-video/src/main/java/com/stonewu/fusion/service/storage/StorageStrategy.java
@@ -2,6 +2,8 @@ package com.stonewu.fusion.service.storage;
 
 import com.stonewu.fusion.entity.storage.StorageConfig;
 
+import java.nio.file.Path;
+
 /**
  * 存储策略接口
  * <p>
@@ -34,4 +36,15 @@ public interface StorageStrategy {
      * @return 持久化后的可访问 URL
      */
     String storeBytes(byte[] data, String subDir, String extension, StorageConfig config);
+
+    /**
+     * 从本地文件保存到当前存储后端。
+     *
+     * @param filePath   本地文件路径
+     * @param subDir     子目录
+     * @param extension  文件扩展名
+     * @param config     存储配置
+     * @return 持久化后的可访问 URL
+     */
+    String storeFile(Path filePath, String subDir, String extension, StorageConfig config);
 }

--- a/ai-fusion-video/src/main/java/com/stonewu/fusion/service/storage/strategy/LocalStorageStrategy.java
+++ b/ai-fusion-video/src/main/java/com/stonewu/fusion/service/storage/strategy/LocalStorageStrategy.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.CopyOption;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -84,6 +85,25 @@ public class LocalStorageStrategy implements StorageStrategy {
             Files.write(target, data);
 
             log.info("[LocalStorage] 文件已保存: {} ({} bytes)", target, data.length);
+            return URL_PREFIX + "/" + subDir + "/" + filename;
+        } catch (IOException e) {
+            throw new RuntimeException("本地存储文件失败: " + e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public String storeFile(Path filePath, String subDir, String extension, StorageConfig config) {
+        String basePath = resolveBasePath(config);
+        String filename = IdUtil.fastSimpleUUID() + "." + extension;
+
+        try {
+            Path dir = Paths.get(basePath, subDir);
+            Files.createDirectories(dir);
+            Path target = dir.resolve(filename);
+            Files.copy(filePath, target, new CopyOption[]{StandardCopyOption.REPLACE_EXISTING});
+
+            long fileSize = Files.size(target);
+            log.info("[LocalStorage] 文件已保存: {} ({} bytes)", target, fileSize);
             return URL_PREFIX + "/" + subDir + "/" + filename;
         } catch (IOException e) {
             throw new RuntimeException("本地存储文件失败: " + e.getMessage(), e);

--- a/ai-fusion-video/src/main/java/com/stonewu/fusion/service/storage/strategy/S3StorageStrategy.java
+++ b/ai-fusion-video/src/main/java/com/stonewu/fusion/service/storage/strategy/S3StorageStrategy.java
@@ -20,6 +20,8 @@ import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
 import java.io.IOException;
 import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -91,6 +93,24 @@ public class S3StorageStrategy implements StorageStrategy {
         return accessUrl;
     }
 
+    @Override
+    public String storeFile(Path filePath, String subDir, String extension, StorageConfig config) {
+        validateConfig(config);
+
+        String objectKey = buildObjectKey(config, subDir, extension);
+        String contentType = guessContentType(extension);
+        uploadFileToS3(config, objectKey, filePath, contentType);
+
+        String accessUrl = buildAccessUrl(config, objectKey);
+        try {
+            log.info("[S3Storage] 文件已上传: key={}, size={} bytes, url={}",
+                    objectKey, Files.size(filePath), accessUrl);
+        } catch (IOException e) {
+            log.info("[S3Storage] 文件已上传: key={}, url={}", objectKey, accessUrl);
+        }
+        return accessUrl;
+    }
+
     private void uploadToS3(StorageConfig config, String objectKey, byte[] data, String contentType) {
         S3Client s3 = buildS3Client(config);
         try {
@@ -101,6 +121,21 @@ public class S3StorageStrategy implements StorageStrategy {
                 putBuilder.contentType(contentType);
             }
             s3.putObject(putBuilder.build(), RequestBody.fromBytes(data));
+        } finally {
+            s3.close();
+        }
+    }
+
+    private void uploadFileToS3(StorageConfig config, String objectKey, Path filePath, String contentType) {
+        S3Client s3 = buildS3Client(config);
+        try {
+            PutObjectRequest.Builder putBuilder = PutObjectRequest.builder()
+                    .bucket(config.getBucketName())
+                    .key(objectKey);
+            if (StrUtil.isNotBlank(contentType)) {
+                putBuilder.contentType(contentType);
+            }
+            s3.putObject(putBuilder.build(), RequestBody.fromFile(filePath));
         } finally {
             s3.close();
         }

--- a/ai-fusion-video/src/main/java/com/stonewu/fusion/service/storyboard/VideoComposeService.java
+++ b/ai-fusion-video/src/main/java/com/stonewu/fusion/service/storyboard/VideoComposeService.java
@@ -1,10 +1,16 @@
 package com.stonewu.fusion.service.storyboard;
 
+import com.baomidou.mybatisplus.core.conditions.update.UpdateWrapper;
+import com.stonewu.fusion.common.BusinessException;
+import com.stonewu.fusion.entity.storage.StorageConfig;
+import com.stonewu.fusion.entity.storyboard.Storyboard;
 import com.stonewu.fusion.entity.storyboard.StoryboardEpisode;
 import com.stonewu.fusion.entity.storyboard.StoryboardItem;
 import com.stonewu.fusion.entity.storyboard.StoryboardScene;
 import com.stonewu.fusion.mapper.storyboard.StoryboardEpisodeMapper;
 import com.stonewu.fusion.service.storage.MediaStorageService;
+import com.stonewu.fusion.service.storage.StorageConfigService;
+import com.stonewu.fusion.service.task.TaskStreamService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
@@ -16,7 +22,9 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.net.IDN;
 import java.net.HttpURLConnection;
+import java.net.InetAddress;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -26,9 +34,13 @@ import java.nio.file.StandardCopyOption;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.Executor;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -42,6 +54,11 @@ import java.util.concurrent.TimeUnit;
 @Slf4j
 public class VideoComposeService {
 
+    private static final String LOCAL_MEDIA_PUBLIC_PREFIX = "/media/";
+    private static final String TASK_TYPE = "storyboard_episode_compose";
+    private static final String TASK_CONTEXT_TYPE = "storyboard_episode";
+    private static final String TASK_INITIAL_MESSAGE = "已提交合成任务，正在拼接镜头视频…";
+
     public static final int STATUS_IDLE = 0;
     public static final int STATUS_RUNNING = 1;
     public static final int STATUS_DONE = 2;
@@ -50,21 +67,36 @@ public class VideoComposeService {
     private final StoryboardService storyboardService;
     private final StoryboardEpisodeMapper episodeMapper;
     private final MediaStorageService mediaStorageService;
+    private final StorageConfigService storageConfigService;
+    private final TaskStreamService taskStreamService;
     private final Executor videoComposeExecutor;
 
-    @Value("${file.media.local.path:/www/wwwroot/aifusionvideo.cc/source/ai-fusion-video/data/media}")
+    @Value("${app.storage.local-base-path:./data/media}")
     private String mediaLocalPath;
 
-    @Value("${file.media.public.prefix:/media/}")
-    private String mediaPublicPrefix;
+    @Value("${video.compose.allowed-hosts:}")
+    private String allowedHostsConfig;
+
+    @Value("${video.compose.max-redirects:3}")
+    private int maxRedirects;
+
+    @Value("${video.compose.ffmpeg-path:ffmpeg}")
+    private String ffmpegPath;
+
+    @Value("${video.compose.ffprobe-path:ffprobe}")
+    private String ffprobePath;
 
     public VideoComposeService(StoryboardService storyboardService,
                                StoryboardEpisodeMapper episodeMapper,
                                MediaStorageService mediaStorageService,
+                               StorageConfigService storageConfigService,
+                               TaskStreamService taskStreamService,
                                @Qualifier("videoComposeExecutor") Executor videoComposeExecutor) {
         this.storyboardService = storyboardService;
         this.episodeMapper = episodeMapper;
         this.mediaStorageService = mediaStorageService;
+        this.storageConfigService = storageConfigService;
+        this.taskStreamService = taskStreamService;
         this.videoComposeExecutor = videoComposeExecutor;
     }
 
@@ -72,40 +104,69 @@ public class VideoComposeService {
      * 提交合成任务。同步标记状态为 RUNNING，异步执行实际合成。
      * 若已在合成中则抛出异常。
      */
-    public void submitCompose(Long episodeId) {
+    public String submitCompose(Long episodeId, Long userId) {
         StoryboardEpisode episode = episodeMapper.selectById(episodeId);
         if (episode == null) {
-            throw new IllegalArgumentException("分镜集不存在: " + episodeId);
-        }
-        Integer status = episode.getComposeStatus();
-        if (status != null && status == STATUS_RUNNING) {
-            throw new IllegalStateException("本集已在合成中，请稍候");
+            throw new BusinessException(404, "分镜集不存在: " + episodeId);
         }
 
-        StoryboardEpisode update = new StoryboardEpisode();
-        update.setId(episodeId);
-        update.setComposeStatus(STATUS_RUNNING);
-        update.setComposeErrorMsg(null);
-        episodeMapper.updateById(update);
+        Storyboard storyboard = storyboardService.getById(episode.getStoryboardId());
+        if (storyboard == null) {
+            throw new BusinessException(404, "分镜不存在: " + episode.getStoryboardId());
+        }
 
-        videoComposeExecutor.execute(() -> {
-            try {
-                doCompose(episodeId);
-            } catch (Throwable t) {
-                log.error("[VideoCompose] 合成失败: episodeId={}", episodeId, t);
-                markFailed(episodeId, t.getMessage());
-            }
-        });
-    }
-
-    private void doCompose(Long episodeId) throws Exception {
-        log.info("[VideoCompose] 开始合成 episodeId={}", episodeId);
-        long startMs = System.currentTimeMillis();
+        String taskId = taskStreamService.createTask(
+                userId,
+                storyboard.getProjectId(),
+                TASK_TYPE,
+                buildTaskTitle(episode),
+                TASK_CONTEXT_TYPE,
+                episodeId,
+                TASK_INITIAL_MESSAGE
+        );
 
         List<String> videoUrls = collectVideoUrls(episodeId);
         if (videoUrls.isEmpty()) {
-            throw new IllegalStateException("本集没有可合成的视频，请先生成镜头视频");
+            String message = "本集没有可合成的视频，请先生成镜头视频";
+            markFailed(episodeId, message);
+            taskStreamService.fail(taskId, message);
+            return taskId;
         }
+
+        int updated = episodeMapper.update(null, new UpdateWrapper<StoryboardEpisode>()
+            .eq("id", episodeId)
+            .ne("compose_status", STATUS_RUNNING)
+            .set("compose_status", STATUS_RUNNING)
+            .set("compose_error_msg", null)
+            .set("composed_video_url", null)
+            .set("composed_at", null));
+        if (updated == 0) {
+            taskStreamService.fail(taskId, "本集已在合成中，请稍候");
+            return taskId;
+        }
+
+        try {
+            videoComposeExecutor.execute(() -> {
+                try {
+                    doCompose(episodeId, taskId, videoUrls);
+                } catch (Throwable t) {
+                    String errorMessage = resolveErrorMessage(t);
+                    log.error("[VideoCompose] 合成失败: episodeId={}", episodeId, t);
+                    markFailed(episodeId, errorMessage);
+                    taskStreamService.fail(taskId, errorMessage);
+                }
+            });
+        } catch (RejectedExecutionException e) {
+            String message = "合成队列繁忙，请稍后重试";
+            markFailed(episodeId, message);
+            taskStreamService.fail(taskId, message);
+        }
+        return taskId;
+    }
+
+    private void doCompose(Long episodeId, String taskId, List<String> videoUrls) throws Exception {
+        log.info("[VideoCompose] 开始合成 episodeId={}, taskId={}", episodeId, taskId);
+        long startMs = System.currentTimeMillis();
         log.info("[VideoCompose] episodeId={}, 待合成视频数={}", episodeId, videoUrls.size());
 
         Path workDir = Files.createTempDirectory("compose_ep_" + episodeId + "_");
@@ -135,8 +196,7 @@ public class VideoComposeService {
                 throw new RuntimeException("ffmpeg 合成失败（concat 与 filter 均失败）");
             }
 
-            byte[] data = Files.readAllBytes(output);
-            String storedUrl = mediaStorageService.storeBytes(data, "videos/composed", "mp4");
+            String storedUrl = mediaStorageService.storeFile(output, "videos/composed", "mp4");
             log.info("[VideoCompose] 已保存到存储: {}", storedUrl);
 
             StoryboardEpisode update = new StoryboardEpisode();
@@ -146,6 +206,8 @@ public class VideoComposeService {
             update.setComposedAt(LocalDateTime.now());
             update.setComposeErrorMsg(null);
             episodeMapper.updateById(update);
+
+                taskStreamService.complete(taskId, "✓ 合成完成 · 视频地址：" + storedUrl);
 
             log.info("[VideoCompose] 完成 episodeId={}, 耗时={}ms, 视频数={}",
                     episodeId, System.currentTimeMillis() - startMs, videoUrls.size());
@@ -158,13 +220,35 @@ public class VideoComposeService {
         }
     }
 
+    private String buildTaskTitle(StoryboardEpisode episode) {
+        String episodeLabel = StringUtils.hasText(episode.getTitle())
+                ? episode.getTitle().trim()
+                : (episode.getEpisodeNumber() != null
+                ? "第 " + episode.getEpisodeNumber() + " 集"
+                : "集 " + episode.getId());
+        return "合成本集视频：" + episodeLabel;
+    }
+
+    private String resolveErrorMessage(Throwable throwable) {
+        if (throwable == null) {
+            return "合成失败";
+        }
+        if (isExecutableMissing(throwable)) {
+            return buildMissingExecutableMessage("ffmpeg", "video.compose.ffmpeg-path", getFfmpegExecutable());
+        }
+        if (StringUtils.hasText(throwable.getMessage())) {
+            return throwable.getMessage();
+        }
+        return "合成失败";
+    }
+
     private List<String> collectVideoUrls(Long episodeId) {
-        List<StoryboardScene> scenes = storyboardService.listScenesByEpisode(episodeId);
+        List<StoryboardScene> scenes = new ArrayList<>(storyboardService.listScenesByEpisode(episodeId));
         scenes.sort(Comparator.comparing(s -> Optional.ofNullable(s.getSortOrder()).orElse(0)));
 
         List<String> urls = new ArrayList<>();
         for (StoryboardScene scene : scenes) {
-            List<StoryboardItem> items = storyboardService.listItemsByScene(scene.getId());
+            List<StoryboardItem> items = new ArrayList<>(storyboardService.listItemsByScene(scene.getId()));
             items.sort(Comparator.comparing(i -> Optional.ofNullable(i.getSortOrder()).orElse(0)));
             for (StoryboardItem item : items) {
                 String url = StringUtils.hasText(item.getVideoUrl())
@@ -180,7 +264,7 @@ public class VideoComposeService {
 
     private boolean runFfmpegConcatDemuxer(Path listFile, Path output) throws Exception {
         List<String> cmd = List.of(
-                "ffmpeg", "-y",
+                getFfmpegExecutable(), "-y",
                 "-f", "concat", "-safe", "0",
                 "-i", listFile.toString(),
                 "-c", "copy",
@@ -190,8 +274,13 @@ public class VideoComposeService {
     }
 
     private boolean runFfmpegFilterConcat(List<Path> files, Path output) throws Exception {
+        boolean includeAudio = allFilesHaveAudio(files);
+        if (!includeAudio) {
+            log.warn("[VideoCompose] 检测到至少一个输入无音轨，回退到仅视频重编码 concat");
+        }
+
         List<String> cmd = new ArrayList<>();
-        cmd.add("ffmpeg");
+        cmd.add(getFfmpegExecutable());
         cmd.add("-y");
         for (Path f : files) {
             cmd.add("-i");
@@ -199,21 +288,30 @@ public class VideoComposeService {
         }
         StringBuilder filter = new StringBuilder();
         for (int i = 0; i < files.size(); i++) {
-            filter.append("[").append(i).append(":v][").append(i).append(":a]");
+            filter.append("[").append(i).append(":v]");
+            if (includeAudio) {
+                filter.append("[").append(i).append(":a]");
+            }
         }
-        filter.append("concat=n=").append(files.size()).append(":v=1:a=1[outv][outa]");
+        filter.append("concat=n=").append(files.size())
+                .append(":v=1:a=").append(includeAudio ? 1 : 0)
+                .append(includeAudio ? "[outv][outa]" : "[outv]");
         cmd.add("-filter_complex");
         cmd.add(filter.toString());
         cmd.add("-map");
         cmd.add("[outv]");
-        cmd.add("-map");
-        cmd.add("[outa]");
+        if (includeAudio) {
+            cmd.add("-map");
+            cmd.add("[outa]");
+        }
         cmd.add("-c:v");
         cmd.add("libx264");
         cmd.add("-preset");
         cmd.add("veryfast");
-        cmd.add("-c:a");
-        cmd.add("aac");
+        if (includeAudio) {
+            cmd.add("-c:a");
+            cmd.add("aac");
+        }
         cmd.add("-pix_fmt");
         cmd.add("yuv420p");
         cmd.add(output.toString());
@@ -224,50 +322,87 @@ public class VideoComposeService {
         log.info("[VideoCompose:{}] 执行: {}", tag, String.join(" ", cmd));
         ProcessBuilder pb = new ProcessBuilder(cmd);
         pb.redirectErrorStream(true);
-        Process p = pb.start();
-        try (BufferedReader reader = new BufferedReader(new InputStreamReader(p.getInputStream(), StandardCharsets.UTF_8))) {
-            String line;
-            while ((line = reader.readLine()) != null) {
-                if (log.isDebugEnabled()) {
-                    log.debug("[ffmpeg:{}] {}", tag, line);
-                }
-            }
+        Process p;
+        try {
+            p = pb.start();
+        } catch (IOException e) {
+            throw wrapExecutableStartException(e, "ffmpeg", "video.compose.ffmpeg-path", getFfmpegExecutable());
         }
-        boolean done = p.waitFor(timeoutMinutes, TimeUnit.MINUTES);
-        if (!done) {
+        StringBuffer outputTail = new StringBuffer();
+        Thread outputReader = new Thread(() -> drainProcessOutput(p.getInputStream(), tag, outputTail),
+                "ffmpeg-" + tag + "-output");
+        outputReader.setDaemon(true);
+        outputReader.start();
+
+        boolean done;
+        try {
+            done = p.waitFor(timeoutMinutes, TimeUnit.MINUTES);
+        } catch (InterruptedException e) {
             p.destroyForcibly();
-            log.error("[VideoCompose:{}] 超时，已强制终止", tag);
+            Thread.currentThread().interrupt();
+            throw e;
+        }
+        if (!done) {
+            p.destroy();
+            if (!p.waitFor(5, TimeUnit.SECONDS)) {
+                p.destroyForcibly();
+            }
+            outputReader.join(TimeUnit.SECONDS.toMillis(5));
+            log.error("[VideoCompose:{}] 超时，已强制终止。最近输出: {}", tag, summarizeOutputTail(outputTail));
             return false;
         }
+
+        outputReader.join(TimeUnit.SECONDS.toMillis(5));
         int exit = p.exitValue();
         if (exit != 0) {
-            log.error("[VideoCompose:{}] 退出码非 0: {}", tag, exit);
+            log.error("[VideoCompose:{}] 退出码非 0: {}。最近输出: {}", tag, exit, summarizeOutputTail(outputTail));
             return false;
         }
         return true;
     }
 
     private void downloadToFile(String url, Path dest) throws IOException {
-        if (url.startsWith(mediaPublicPrefix)) {
-            String rel = url.substring(mediaPublicPrefix.length());
-            Path local = Paths.get(mediaLocalPath, rel);
+        if (url.startsWith(LOCAL_MEDIA_PUBLIC_PREFIX)) {
+            Path local = resolveManagedMediaPath(url);
             if (Files.exists(local)) {
                 Files.copy(local, dest, StandardCopyOption.REPLACE_EXISTING);
                 return;
             }
+            if (!isAbsoluteHttpUrl(url)) {
+                throw new IOException("本地媒体文件不存在: " + local);
+            }
             log.warn("[VideoCompose] /media/ 路径文件不存在，回退 HTTP: {}", url);
         }
-        URI uri = URI.create(url);
-        HttpURLConnection conn = (HttpURLConnection) uri.toURL().openConnection();
-        conn.setConnectTimeout(30000);
-        conn.setReadTimeout(180000);
-        conn.setInstanceFollowRedirects(true);
-        int code = conn.getResponseCode();
-        if (code < 200 || code >= 300) {
-            throw new IOException("下载失败 HTTP " + code + ": " + url);
-        }
-        try (InputStream in = conn.getInputStream()) {
-            Files.copy(in, dest, StandardCopyOption.REPLACE_EXISTING);
+
+        URI current = URI.create(url);
+        int redirects = 0;
+        while (true) {
+            validateRemoteUri(current);
+            HttpURLConnection conn = openConnection(current);
+            try {
+                int code = conn.getResponseCode();
+                if (isRedirect(code)) {
+                    if (redirects >= maxRedirects) {
+                        throw new IOException("下载重定向次数过多: " + url);
+                    }
+                    String location = conn.getHeaderField("Location");
+                    if (!StringUtils.hasText(location)) {
+                        throw new IOException("下载重定向缺少 Location: " + url);
+                    }
+                    current = current.resolve(location);
+                    redirects++;
+                    continue;
+                }
+                if (code < 200 || code >= 300) {
+                    throw new IOException("下载失败 HTTP " + code + ": " + current);
+                }
+                try (InputStream in = conn.getInputStream()) {
+                    Files.copy(in, dest, StandardCopyOption.REPLACE_EXISTING);
+                    return;
+                }
+            } finally {
+                conn.disconnect();
+            }
         }
     }
 
@@ -278,9 +413,252 @@ public class VideoComposeService {
             update.setId(episodeId);
             update.setComposeStatus(STATUS_FAILED);
             update.setComposeErrorMsg(trimmed);
+            update.setComposedVideoUrl(null);
+            update.setComposedAt(null);
             episodeMapper.updateById(update);
         } catch (Exception e) {
             log.error("[VideoCompose] 更新失败状态异常", e);
         }
+    }
+
+    private boolean allFilesHaveAudio(List<Path> files) {
+        for (Path file : files) {
+            if (!hasAudioStream(file)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private boolean hasAudioStream(Path file) {
+        List<String> cmd = List.of(
+            getFfprobeExecutable(), "-v", "error",
+                "-select_streams", "a",
+                "-show_entries", "stream=index",
+                "-of", "csv=p=0",
+                file.toString()
+        );
+        try {
+            Process process = new ProcessBuilder(cmd)
+                    .redirectErrorStream(true)
+                    .start();
+            boolean done = process.waitFor(15, TimeUnit.SECONDS);
+            if (!done) {
+                process.destroyForcibly();
+                log.warn("[VideoCompose] ffprobe 检测音轨超时: {}", file);
+                return false;
+            }
+            String output;
+            try (InputStream in = process.getInputStream()) {
+                output = new String(in.readAllBytes(), StandardCharsets.UTF_8);
+            }
+            if (process.exitValue() != 0) {
+                log.warn("[VideoCompose] ffprobe 检测音轨失败，按无音轨处理: {}", file);
+                return false;
+            }
+            return StringUtils.hasText(output.trim());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            log.warn("[VideoCompose] ffprobe 检测音轨被中断: {}", file, e);
+            return false;
+        } catch (IOException e) {
+            IOException wrapped = wrapExecutableStartException(
+                    e,
+                    "ffprobe",
+                    "video.compose.ffprobe-path",
+                    getFfprobeExecutable()
+            );
+            log.warn("[VideoCompose] ffprobe 不可用或检测失败，按无音轨处理: {}", file, wrapped);
+            return false;
+        }
+    }
+
+    private String getFfmpegExecutable() {
+        return StringUtils.hasText(ffmpegPath) ? ffmpegPath.trim() : "ffmpeg";
+    }
+
+    private String getFfprobeExecutable() {
+        return StringUtils.hasText(ffprobePath) ? ffprobePath.trim() : "ffprobe";
+    }
+
+    private IOException wrapExecutableStartException(IOException exception,
+                                                     String executableName,
+                                                     String propertyName,
+                                                     String configuredValue) {
+        if (!isExecutableMissing(exception)) {
+            return exception;
+        }
+        return new IOException(buildMissingExecutableMessage(executableName, propertyName, configuredValue), exception);
+    }
+
+    private boolean isExecutableMissing(Throwable throwable) {
+        Throwable current = throwable;
+        while (current != null) {
+            String message = current.getMessage();
+            if (StringUtils.hasText(message)) {
+                String normalized = message.toLowerCase(Locale.ROOT);
+                if (normalized.contains("createprocess error=2")
+                        || normalized.contains("系统找不到指定的文件")
+                        || normalized.contains("no such file or directory")
+                        || normalized.contains("cannot run program")) {
+                    return true;
+                }
+            }
+            current = current.getCause();
+        }
+        return false;
+    }
+
+    private String buildMissingExecutableMessage(String executableName,
+                                                String propertyName,
+                                                String configuredValue) {
+        return "未找到 " + executableName + " 可执行文件，请先安装 " + executableName
+                + "，或在配置中设置 " + propertyName + "。当前值：" + configuredValue;
+    }
+
+    private void drainProcessOutput(InputStream inputStream, String tag, StringBuffer outputTail) {
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                appendOutputTail(outputTail, line);
+                if (log.isDebugEnabled()) {
+                    log.debug("[ffmpeg:{}] {}", tag, line);
+                }
+            }
+        } catch (IOException e) {
+            log.warn("[VideoCompose:{}] 读取 ffmpeg 输出失败", tag, e);
+        }
+    }
+
+    private void appendOutputTail(StringBuffer outputTail, String line) {
+        synchronized (outputTail) {
+            if (outputTail.length() > 0) {
+                outputTail.append(System.lineSeparator());
+            }
+            outputTail.append(line);
+            int maxLength = 4000;
+            if (outputTail.length() > maxLength) {
+                outputTail.delete(0, outputTail.length() - maxLength);
+            }
+        }
+    }
+
+    private String summarizeOutputTail(StringBuffer outputTail) {
+        synchronized (outputTail) {
+            return outputTail.isEmpty() ? "<no output>" : outputTail.toString();
+        }
+    }
+
+    private Path resolveManagedMediaPath(String url) throws IOException {
+        String rel = url.substring(LOCAL_MEDIA_PUBLIC_PREFIX.length());
+        Path relativePath = Paths.get(rel).normalize();
+        if (relativePath.isAbsolute() || relativePath.startsWith("..")) {
+            throw new IOException("非法媒体相对路径: " + rel);
+        }
+
+        Path basePath = resolveLocalMediaBasePath();
+        Path resolved = basePath.resolve(relativePath).normalize();
+        if (!resolved.startsWith(basePath)) {
+            throw new IOException("媒体路径越界: " + rel);
+        }
+        return resolved;
+    }
+
+    private Path resolveLocalMediaBasePath() {
+        String basePath = mediaLocalPath;
+        try {
+            StorageConfig config = storageConfigService.getDefaultConfig();
+            if (config != null
+                    && "local".equalsIgnoreCase(config.getType())
+                    && StringUtils.hasText(config.getBasePath())) {
+                basePath = config.getBasePath();
+            }
+        } catch (Exception e) {
+            log.debug("[VideoCompose] 读取默认存储配置失败，回退到 application 配置路径: {}", basePath, e);
+        }
+        return Paths.get(basePath).toAbsolutePath().normalize();
+    }
+
+    private HttpURLConnection openConnection(URI uri) throws IOException {
+        HttpURLConnection conn = (HttpURLConnection) uri.toURL().openConnection();
+        conn.setConnectTimeout(30000);
+        conn.setReadTimeout(180000);
+        conn.setInstanceFollowRedirects(false);
+        return conn;
+    }
+
+    private void validateRemoteUri(URI uri) throws IOException {
+        String scheme = uri.getScheme() == null ? "" : uri.getScheme().toLowerCase(Locale.ROOT);
+        if (!"http".equals(scheme) && !"https".equals(scheme)) {
+            throw new IOException("仅允许下载 http/https 资源: " + uri);
+        }
+
+        String host = uri.getHost();
+        if (!StringUtils.hasText(host)) {
+            throw new IOException("下载地址缺少 host: " + uri);
+        }
+
+        String normalizedHost = IDN.toASCII(host).toLowerCase(Locale.ROOT);
+        Set<String> allowedHosts = parseAllowedHosts();
+        if (!allowedHosts.isEmpty()) {
+            if (!matchesAllowedHost(normalizedHost, allowedHosts)) {
+                throw new IOException("下载地址 host 不在白名单: " + normalizedHost);
+            }
+            return;
+        }
+
+        InetAddress[] addresses = InetAddress.getAllByName(normalizedHost);
+        for (InetAddress address : addresses) {
+            if (address.isAnyLocalAddress()
+                    || address.isLoopbackAddress()
+                    || address.isLinkLocalAddress()
+                    || address.isSiteLocalAddress()
+                    || address.isMulticastAddress()) {
+                throw new IOException("拒绝访问内网或本地地址: " + normalizedHost);
+            }
+        }
+    }
+
+    private Set<String> parseAllowedHosts() {
+        Set<String> hosts = new LinkedHashSet<>();
+        if (!StringUtils.hasText(allowedHostsConfig)) {
+            return hosts;
+        }
+        for (String token : allowedHostsConfig.split(",")) {
+            String trimmed = token.trim().toLowerCase(Locale.ROOT);
+            if (!trimmed.isEmpty()) {
+                hosts.add(trimmed);
+            }
+        }
+        return hosts;
+    }
+
+    private boolean matchesAllowedHost(String host, Set<String> allowedHosts) {
+        for (String pattern : allowedHosts) {
+            if (pattern.startsWith("*.")) {
+                String suffix = pattern.substring(1);
+                if (host.endsWith(suffix)) {
+                    return true;
+                }
+                continue;
+            }
+            if (host.equals(pattern) || host.endsWith("." + pattern)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean isRedirect(int statusCode) {
+        return statusCode == HttpURLConnection.HTTP_MOVED_PERM
+                || statusCode == HttpURLConnection.HTTP_MOVED_TEMP
+                || statusCode == HttpURLConnection.HTTP_SEE_OTHER
+                || statusCode == 307
+                || statusCode == 308;
+    }
+
+    private boolean isAbsoluteHttpUrl(String url) {
+        String lower = url.toLowerCase(Locale.ROOT);
+        return lower.startsWith("http://") || lower.startsWith("https://");
     }
 }

--- a/ai-fusion-video/src/main/java/com/stonewu/fusion/service/storyboard/VideoComposeService.java
+++ b/ai-fusion-video/src/main/java/com/stonewu/fusion/service/storyboard/VideoComposeService.java
@@ -1,0 +1,286 @@
+package com.stonewu.fusion.service.storyboard;
+
+import com.stonewu.fusion.entity.storyboard.StoryboardEpisode;
+import com.stonewu.fusion.entity.storyboard.StoryboardItem;
+import com.stonewu.fusion.entity.storyboard.StoryboardScene;
+import com.stonewu.fusion.mapper.storyboard.StoryboardEpisodeMapper;
+import com.stonewu.fusion.service.storage.MediaStorageService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.util.FileSystemUtils;
+import org.springframework.util.StringUtils;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * 按集合成视频服务。
+ * <p>
+ * 流程：取该集所有场次的所有镜头视频（按 sortOrder 排序），下载到临时目录，
+ * 用 ffmpeg concat 拼接（先尝试 demuxer 零转码；失败则 fallback 到 filter_complex 重新编码），
+ * 然后通过 MediaStorageService 持久化，更新 episode 的合成状态与URL。
+ */
+@Service
+@Slf4j
+public class VideoComposeService {
+
+    public static final int STATUS_IDLE = 0;
+    public static final int STATUS_RUNNING = 1;
+    public static final int STATUS_DONE = 2;
+    public static final int STATUS_FAILED = 3;
+
+    private final StoryboardService storyboardService;
+    private final StoryboardEpisodeMapper episodeMapper;
+    private final MediaStorageService mediaStorageService;
+    private final Executor videoComposeExecutor;
+
+    @Value("${file.media.local.path:/www/wwwroot/aifusionvideo.cc/source/ai-fusion-video/data/media}")
+    private String mediaLocalPath;
+
+    @Value("${file.media.public.prefix:/media/}")
+    private String mediaPublicPrefix;
+
+    public VideoComposeService(StoryboardService storyboardService,
+                               StoryboardEpisodeMapper episodeMapper,
+                               MediaStorageService mediaStorageService,
+                               @Qualifier("videoComposeExecutor") Executor videoComposeExecutor) {
+        this.storyboardService = storyboardService;
+        this.episodeMapper = episodeMapper;
+        this.mediaStorageService = mediaStorageService;
+        this.videoComposeExecutor = videoComposeExecutor;
+    }
+
+    /**
+     * 提交合成任务。同步标记状态为 RUNNING，异步执行实际合成。
+     * 若已在合成中则抛出异常。
+     */
+    public void submitCompose(Long episodeId) {
+        StoryboardEpisode episode = episodeMapper.selectById(episodeId);
+        if (episode == null) {
+            throw new IllegalArgumentException("分镜集不存在: " + episodeId);
+        }
+        Integer status = episode.getComposeStatus();
+        if (status != null && status == STATUS_RUNNING) {
+            throw new IllegalStateException("本集已在合成中，请稍候");
+        }
+
+        StoryboardEpisode update = new StoryboardEpisode();
+        update.setId(episodeId);
+        update.setComposeStatus(STATUS_RUNNING);
+        update.setComposeErrorMsg(null);
+        episodeMapper.updateById(update);
+
+        videoComposeExecutor.execute(() -> {
+            try {
+                doCompose(episodeId);
+            } catch (Throwable t) {
+                log.error("[VideoCompose] 合成失败: episodeId={}", episodeId, t);
+                markFailed(episodeId, t.getMessage());
+            }
+        });
+    }
+
+    private void doCompose(Long episodeId) throws Exception {
+        log.info("[VideoCompose] 开始合成 episodeId={}", episodeId);
+        long startMs = System.currentTimeMillis();
+
+        List<String> videoUrls = collectVideoUrls(episodeId);
+        if (videoUrls.isEmpty()) {
+            throw new IllegalStateException("本集没有可合成的视频，请先生成镜头视频");
+        }
+        log.info("[VideoCompose] episodeId={}, 待合成视频数={}", episodeId, videoUrls.size());
+
+        Path workDir = Files.createTempDirectory("compose_ep_" + episodeId + "_");
+        try {
+            List<Path> localFiles = new ArrayList<>();
+            for (int i = 0; i < videoUrls.size(); i++) {
+                Path local = workDir.resolve(String.format("v%04d.mp4", i));
+                downloadToFile(videoUrls.get(i), local);
+                localFiles.add(local);
+            }
+
+            Path listFile = workDir.resolve("list.txt");
+            StringBuilder sb = new StringBuilder();
+            for (Path f : localFiles) {
+                String s = f.toAbsolutePath().toString().replace("'", "'\\''");
+                sb.append("file '").append(s).append("'\n");
+            }
+            Files.writeString(listFile, sb.toString(), StandardCharsets.UTF_8);
+
+            Path output = workDir.resolve("output.mp4");
+            boolean ok = runFfmpegConcatDemuxer(listFile, output);
+            if (!ok) {
+                log.warn("[VideoCompose] concat demuxer 失败，回退到 filter_complex episodeId={}", episodeId);
+                ok = runFfmpegFilterConcat(localFiles, output);
+            }
+            if (!ok || !Files.exists(output) || Files.size(output) == 0) {
+                throw new RuntimeException("ffmpeg 合成失败（concat 与 filter 均失败）");
+            }
+
+            byte[] data = Files.readAllBytes(output);
+            String storedUrl = mediaStorageService.storeBytes(data, "videos/composed", "mp4");
+            log.info("[VideoCompose] 已保存到存储: {}", storedUrl);
+
+            StoryboardEpisode update = new StoryboardEpisode();
+            update.setId(episodeId);
+            update.setComposedVideoUrl(storedUrl);
+            update.setComposeStatus(STATUS_DONE);
+            update.setComposedAt(LocalDateTime.now());
+            update.setComposeErrorMsg(null);
+            episodeMapper.updateById(update);
+
+            log.info("[VideoCompose] 完成 episodeId={}, 耗时={}ms, 视频数={}",
+                    episodeId, System.currentTimeMillis() - startMs, videoUrls.size());
+        } finally {
+            try {
+                FileSystemUtils.deleteRecursively(workDir.toFile());
+            } catch (Exception e) {
+                log.warn("[VideoCompose] 临时目录清理失败 {}", workDir, e);
+            }
+        }
+    }
+
+    private List<String> collectVideoUrls(Long episodeId) {
+        List<StoryboardScene> scenes = storyboardService.listScenesByEpisode(episodeId);
+        scenes.sort(Comparator.comparing(s -> Optional.ofNullable(s.getSortOrder()).orElse(0)));
+
+        List<String> urls = new ArrayList<>();
+        for (StoryboardScene scene : scenes) {
+            List<StoryboardItem> items = storyboardService.listItemsByScene(scene.getId());
+            items.sort(Comparator.comparing(i -> Optional.ofNullable(i.getSortOrder()).orElse(0)));
+            for (StoryboardItem item : items) {
+                String url = StringUtils.hasText(item.getVideoUrl())
+                        ? item.getVideoUrl()
+                        : item.getGeneratedVideoUrl();
+                if (StringUtils.hasText(url)) {
+                    urls.add(url);
+                }
+            }
+        }
+        return urls;
+    }
+
+    private boolean runFfmpegConcatDemuxer(Path listFile, Path output) throws Exception {
+        List<String> cmd = List.of(
+                "ffmpeg", "-y",
+                "-f", "concat", "-safe", "0",
+                "-i", listFile.toString(),
+                "-c", "copy",
+                output.toString()
+        );
+        return runFfmpeg(cmd, "concat-demuxer", 15);
+    }
+
+    private boolean runFfmpegFilterConcat(List<Path> files, Path output) throws Exception {
+        List<String> cmd = new ArrayList<>();
+        cmd.add("ffmpeg");
+        cmd.add("-y");
+        for (Path f : files) {
+            cmd.add("-i");
+            cmd.add(f.toString());
+        }
+        StringBuilder filter = new StringBuilder();
+        for (int i = 0; i < files.size(); i++) {
+            filter.append("[").append(i).append(":v][").append(i).append(":a]");
+        }
+        filter.append("concat=n=").append(files.size()).append(":v=1:a=1[outv][outa]");
+        cmd.add("-filter_complex");
+        cmd.add(filter.toString());
+        cmd.add("-map");
+        cmd.add("[outv]");
+        cmd.add("-map");
+        cmd.add("[outa]");
+        cmd.add("-c:v");
+        cmd.add("libx264");
+        cmd.add("-preset");
+        cmd.add("veryfast");
+        cmd.add("-c:a");
+        cmd.add("aac");
+        cmd.add("-pix_fmt");
+        cmd.add("yuv420p");
+        cmd.add(output.toString());
+        return runFfmpeg(cmd, "filter-complex", 30);
+    }
+
+    private boolean runFfmpeg(List<String> cmd, String tag, int timeoutMinutes) throws Exception {
+        log.info("[VideoCompose:{}] 执行: {}", tag, String.join(" ", cmd));
+        ProcessBuilder pb = new ProcessBuilder(cmd);
+        pb.redirectErrorStream(true);
+        Process p = pb.start();
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(p.getInputStream(), StandardCharsets.UTF_8))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                if (log.isDebugEnabled()) {
+                    log.debug("[ffmpeg:{}] {}", tag, line);
+                }
+            }
+        }
+        boolean done = p.waitFor(timeoutMinutes, TimeUnit.MINUTES);
+        if (!done) {
+            p.destroyForcibly();
+            log.error("[VideoCompose:{}] 超时，已强制终止", tag);
+            return false;
+        }
+        int exit = p.exitValue();
+        if (exit != 0) {
+            log.error("[VideoCompose:{}] 退出码非 0: {}", tag, exit);
+            return false;
+        }
+        return true;
+    }
+
+    private void downloadToFile(String url, Path dest) throws IOException {
+        if (url.startsWith(mediaPublicPrefix)) {
+            String rel = url.substring(mediaPublicPrefix.length());
+            Path local = Paths.get(mediaLocalPath, rel);
+            if (Files.exists(local)) {
+                Files.copy(local, dest, StandardCopyOption.REPLACE_EXISTING);
+                return;
+            }
+            log.warn("[VideoCompose] /media/ 路径文件不存在，回退 HTTP: {}", url);
+        }
+        URI uri = URI.create(url);
+        HttpURLConnection conn = (HttpURLConnection) uri.toURL().openConnection();
+        conn.setConnectTimeout(30000);
+        conn.setReadTimeout(180000);
+        conn.setInstanceFollowRedirects(true);
+        int code = conn.getResponseCode();
+        if (code < 200 || code >= 300) {
+            throw new IOException("下载失败 HTTP " + code + ": " + url);
+        }
+        try (InputStream in = conn.getInputStream()) {
+            Files.copy(in, dest, StandardCopyOption.REPLACE_EXISTING);
+        }
+    }
+
+    private void markFailed(Long episodeId, String msg) {
+        try {
+            String trimmed = msg == null ? "未知错误" : (msg.length() > 1000 ? msg.substring(0, 1000) : msg);
+            StoryboardEpisode update = new StoryboardEpisode();
+            update.setId(episodeId);
+            update.setComposeStatus(STATUS_FAILED);
+            update.setComposeErrorMsg(trimmed);
+            episodeMapper.updateById(update);
+        } catch (Exception e) {
+            log.error("[VideoCompose] 更新失败状态异常", e);
+        }
+    }
+}

--- a/ai-fusion-video/src/main/java/com/stonewu/fusion/service/task/TaskStreamService.java
+++ b/ai-fusion-video/src/main/java/com/stonewu/fusion/service/task/TaskStreamService.java
@@ -1,0 +1,114 @@
+package com.stonewu.fusion.service.task;
+
+import cn.hutool.core.util.IdUtil;
+import cn.hutool.core.util.StrUtil;
+import com.stonewu.fusion.controller.ai.vo.AiChatStreamRespVO;
+import com.stonewu.fusion.entity.ai.AgentConversation;
+import com.stonewu.fusion.service.ai.AgentConversationService;
+import com.stonewu.fusion.service.ai.AgentMessageService;
+import com.stonewu.fusion.service.ai.AiStreamRedisService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Flux;
+
+import java.util.List;
+
+/**
+ * 通用任务流服务。
+ * <p>
+ * 复用现有 conversation/message/Redis Stream 基础设施，
+ * 让非 AI 的长任务也能拥有稳定的后端 taskId、SSE 重连与历史记录能力。
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class TaskStreamService {
+
+    public static final String CATEGORY_TASK = "task";
+
+    private final AgentConversationService conversationService;
+    private final AgentMessageService messageService;
+    private final AiStreamRedisService aiStreamRedisService;
+
+    public String createTask(Long userId,
+                             Long projectId,
+                             String taskType,
+                             String title,
+                             String contextType,
+                             Long contextId,
+                             String initialContent) {
+        String taskId = IdUtil.fastSimpleUUID();
+        conversationService.createOrUpdate(taskId, userId, projectId,
+                contextType, contextId, taskType, title, CATEGORY_TASK);
+        aiStreamRedisService.cleanup(taskId);
+        aiStreamRedisService.markActive(taskId);
+        if (StrUtil.isNotBlank(initialContent)) {
+            publishContent(taskId, initialContent);
+        }
+        return taskId;
+    }
+
+    public void publishContent(String taskId, String content) {
+        if (StrUtil.isBlank(content)) {
+            return;
+        }
+        messageService.saveAssistantMessage(taskId, content, null, null);
+        aiStreamRedisService.publish(taskId, new AiChatStreamRespVO()
+                .setConversationId(taskId)
+                .setOutputType("CONTENT")
+                .setContent(content)
+                .setFinished(false));
+    }
+
+    public void complete(String taskId, String content) {
+        if (StrUtil.isNotBlank(content)) {
+            messageService.saveAssistantMessage(taskId, content, null, null);
+        }
+        aiStreamRedisService.publish(taskId, new AiChatStreamRespVO()
+                .setConversationId(taskId)
+                .setOutputType("DONE")
+                .setContent(content)
+                .setFinished(true));
+        aiStreamRedisService.markCompleted(taskId);
+        aiStreamRedisService.scheduleCleanup(taskId);
+        conversationService.finish(taskId, "completed");
+        log.info("[TaskStream] 任务完成: taskId={}", taskId);
+    }
+
+    public void fail(String taskId, String errorMessage) {
+        String safeMessage = StrUtil.blankToDefault(errorMessage, "任务失败");
+        String content = safeMessage;
+        messageService.saveAssistantMessage(taskId, content, null, null);
+        aiStreamRedisService.publish(taskId, new AiChatStreamRespVO()
+                .setConversationId(taskId)
+                .setOutputType("CONTENT")
+                .setContent(content)
+                .setFinished(false));
+        aiStreamRedisService.publish(taskId, new AiChatStreamRespVO()
+                .setConversationId(taskId)
+                .setOutputType("ERROR")
+                .setError(safeMessage)
+                .setFinished(true));
+        aiStreamRedisService.markError(taskId);
+        aiStreamRedisService.scheduleCleanup(taskId);
+        conversationService.finish(taskId, "failed");
+        log.warn("[TaskStream] 任务失败: taskId={}, message={}", taskId, safeMessage);
+    }
+
+    public Flux<AiChatStreamRespVO> reconnect(String taskId) {
+        String status = aiStreamRedisService.getStatus(taskId);
+        if ("NONE".equals(status)) {
+            return Flux.empty();
+        }
+        return aiStreamRedisService.subscribe(taskId);
+    }
+
+    public String getStatus(String taskId) {
+        return aiStreamRedisService.getStatus(taskId);
+    }
+
+    public List<AgentConversation> listRunning(Long userId) {
+        return conversationService.listRunning(userId);
+    }
+}

--- a/ai-fusion-video/src/main/resources/application-local.yaml
+++ b/ai-fusion-video/src/main/resources/application-local.yaml
@@ -35,6 +35,12 @@ fusion:
   agentscope:
     shutdown-timeout: 3s
 
+video:
+  compose:
+    # 本地未加入 PATH 时，可直接改成绝对路径，例如 C:/ffmpeg/bin/ffmpeg.exe
+    ffmpeg-path: ${VIDEO_COMPOSE_FFMPEG_PATH:D:\ffmpeg-7.1.1-full_build\bin\ffmpeg.exe}
+    ffprobe-path: ${VIDEO_COMPOSE_FFPROBE_PATH:D:\ffmpeg-7.1.1-full_build\bin\ffprobe.exe}
+
 # 日志级别（本地开发调高）
 logging:
   level:

--- a/ai-fusion-video/src/main/resources/application.yaml
+++ b/ai-fusion-video/src/main/resources/application.yaml
@@ -45,3 +45,8 @@ server:
 app:
   storage:
     local-base-path: ./data/media
+
+video:
+  compose:
+    ffmpeg-path: ${VIDEO_COMPOSE_FFMPEG_PATH:ffmpeg}
+    ffprobe-path: ${VIDEO_COMPOSE_FFPROBE_PATH:ffprobe}

--- a/ai-fusion-video/src/main/resources/db/migration/V1.0.5.0.2__add_episode_compose_video.sql
+++ b/ai-fusion-video/src/main/resources/db/migration/V1.0.5.0.2__add_episode_compose_video.sql
@@ -1,0 +1,5 @@
+ALTER TABLE afv_storyboard_episode
+    ADD COLUMN composed_video_url VARCHAR(512) NULL COMMENT '本集合成视频URL',
+    ADD COLUMN compose_status TINYINT NOT NULL DEFAULT 0 COMMENT '合成状态: 0未开始 1合成中 2已完成 3失败',
+    ADD COLUMN compose_error_msg VARCHAR(1024) NULL COMMENT '合成失败原因',
+    ADD COLUMN composed_at DATETIME NULL COMMENT '合成完成时间';

--- a/ai-fusion-video/src/test/java/com/stonewu/fusion/service/storyboard/VideoComposeServiceTests.java
+++ b/ai-fusion-video/src/test/java/com/stonewu/fusion/service/storyboard/VideoComposeServiceTests.java
@@ -1,0 +1,197 @@
+package com.stonewu.fusion.service.storyboard;
+
+import com.baomidou.mybatisplus.core.conditions.update.UpdateWrapper;
+import com.stonewu.fusion.entity.storage.StorageConfig;
+import com.stonewu.fusion.entity.storyboard.Storyboard;
+import com.stonewu.fusion.entity.storyboard.StoryboardEpisode;
+import com.stonewu.fusion.mapper.storyboard.StoryboardEpisodeMapper;
+import com.stonewu.fusion.service.storage.MediaStorageService;
+import com.stonewu.fusion.service.storage.StorageConfigService;
+import com.stonewu.fusion.service.task.TaskStreamService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.concurrent.Executor;
+import java.util.concurrent.RejectedExecutionException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class VideoComposeServiceTests {
+
+    @Mock
+    private StoryboardService storyboardService;
+
+    @Mock
+    private StoryboardEpisodeMapper episodeMapper;
+
+    @Mock
+    private MediaStorageService mediaStorageService;
+
+    @Mock
+    private StorageConfigService storageConfigService;
+
+    @Mock
+    private TaskStreamService taskStreamService;
+
+    @Mock
+    private Executor videoComposeExecutor;
+
+    private VideoComposeService videoComposeService;
+
+    @BeforeEach
+    void setUp() {
+        videoComposeService = new VideoComposeService(
+                storyboardService,
+                episodeMapper,
+                mediaStorageService,
+                storageConfigService,
+                taskStreamService,
+                videoComposeExecutor
+        );
+        ReflectionTestUtils.setField(videoComposeService, "mediaLocalPath", "D:/media-root");
+        ReflectionTestUtils.setField(videoComposeService, "allowedHostsConfig", "");
+        ReflectionTestUtils.setField(videoComposeService, "maxRedirects", 3);
+        ReflectionTestUtils.setField(videoComposeService, "ffmpegPath", "ffmpeg");
+        ReflectionTestUtils.setField(videoComposeService, "ffprobePath", "ffprobe");
+    }
+
+    @Test
+    void submitComposeUsesConditionalUpdateBeforeScheduling() {
+        when(episodeMapper.selectById(11L)).thenReturn(StoryboardEpisode.builder().id(11L).storyboardId(21L).build());
+        when(storyboardService.getById(21L)).thenReturn(Storyboard.builder().id(21L).projectId(31L).build());
+        when(taskStreamService.createTask(eq(99L), eq(31L), eq("storyboard_episode_compose"), any(String.class), eq("storyboard_episode"), eq(11L), any(String.class)))
+            .thenReturn("task-1");
+        when(storyboardService.listScenesByEpisode(11L)).thenReturn(List.of());
+        String taskId = videoComposeService.submitCompose(11L, 99L);
+
+        assertThat(taskId).isEqualTo("task-1");
+        verify(taskStreamService).fail("task-1", "本集没有可合成的视频，请先生成镜头视频");
+        verifyNoInteractions(videoComposeExecutor);
+    }
+
+    @Test
+    void submitComposeUsesConditionalUpdateBeforeSchedulingWhenVideoExists() {
+        when(episodeMapper.selectById(11L)).thenReturn(StoryboardEpisode.builder()
+            .id(11L)
+            .storyboardId(21L)
+            .episodeNumber(1)
+            .title("第一集")
+            .build());
+        when(storyboardService.getById(21L)).thenReturn(Storyboard.builder().id(21L).projectId(31L).build());
+        when(taskStreamService.createTask(eq(99L), eq(31L), eq("storyboard_episode_compose"), any(String.class), eq("storyboard_episode"), eq(11L), any(String.class)))
+            .thenReturn("task-1");
+        when(storyboardService.listScenesByEpisode(11L)).thenReturn(List.of(
+                com.stonewu.fusion.entity.storyboard.StoryboardScene.builder().id(101L).sortOrder(0).build()
+        ));
+        when(storyboardService.listItemsByScene(101L)).thenReturn(List.of(
+                com.stonewu.fusion.entity.storyboard.StoryboardItem.builder().id(201L).sortOrder(0).videoUrl("/media/videos/demo.mp4").build()
+        ));
+        when(episodeMapper.update(eq(null), any(UpdateWrapper.class))).thenReturn(1);
+
+        String taskId = videoComposeService.submitCompose(11L, 99L);
+
+        assertThat(taskId).isEqualTo("task-1");
+        verify(episodeMapper).update(eq(null), any(UpdateWrapper.class));
+        verify(videoComposeExecutor).execute(any(Runnable.class));
+    }
+
+    @Test
+    void submitComposeMarksFailedWhenExecutorRejectsTask() {
+        when(episodeMapper.selectById(11L)).thenReturn(StoryboardEpisode.builder().id(11L).storyboardId(21L).build());
+        when(storyboardService.getById(21L)).thenReturn(Storyboard.builder().id(21L).projectId(31L).build());
+        when(taskStreamService.createTask(eq(99L), eq(31L), eq("storyboard_episode_compose"), any(String.class), eq("storyboard_episode"), eq(11L), any(String.class)))
+            .thenReturn("task-1");
+        when(storyboardService.listScenesByEpisode(11L)).thenReturn(List.of(
+                com.stonewu.fusion.entity.storyboard.StoryboardScene.builder().id(101L).sortOrder(0).build()
+        ));
+        when(storyboardService.listItemsByScene(101L)).thenReturn(List.of(
+                com.stonewu.fusion.entity.storyboard.StoryboardItem.builder().id(201L).sortOrder(0).videoUrl("/media/videos/demo.mp4").build()
+        ));
+        when(episodeMapper.update(eq(null), any(UpdateWrapper.class))).thenReturn(1);
+        org.mockito.Mockito.doThrow(new RejectedExecutionException("busy"))
+                .when(videoComposeExecutor)
+                .execute(any(Runnable.class));
+
+        String taskId = videoComposeService.submitCompose(11L, 99L);
+
+        assertThat(taskId).isEqualTo("task-1");
+        ArgumentCaptor<StoryboardEpisode> captor = ArgumentCaptor.forClass(StoryboardEpisode.class);
+        verify(episodeMapper).updateById(captor.capture());
+        assertThat(captor.getValue().getId()).isEqualTo(11L);
+        assertThat(captor.getValue().getComposeStatus()).isEqualTo(VideoComposeService.STATUS_FAILED);
+        assertThat(captor.getValue().getComposeErrorMsg()).contains("合成队列繁忙");
+        assertThat(captor.getValue().getComposedVideoUrl()).isNull();
+        assertThat(captor.getValue().getComposedAt()).isNull();
+        verify(taskStreamService).fail("task-1", "合成队列繁忙，请稍后重试");
+    }
+
+    @Test
+    void validateRemoteUriRejectsLoopbackAddress() {
+        assertThatThrownBy(() -> invokePrivate("validateRemoteUri", java.net.URI.create("http://127.0.0.1/test.mp4")))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("拒绝访问内网或本地地址");
+    }
+
+    @Test
+    void resolveManagedMediaPathRejectsPathTraversal() {
+        assertThatThrownBy(() -> invokePrivate("resolveManagedMediaPath", "/media/../../windows/system32/config/sam"))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("非法媒体相对路径");
+    }
+
+    @Test
+    void resolveManagedMediaPathPrefersDefaultLocalStorageBasePath() throws Throwable {
+        when(storageConfigService.getDefaultConfig()).thenReturn(StorageConfig.builder()
+                .type("local")
+                .basePath("D:/configured-media")
+                .build());
+
+        Object resolved = invokePrivate("resolveManagedMediaPath", "/media/videos/test.mp4");
+
+        assertThat(resolved)
+            .isEqualTo(java.nio.file.Paths.get("D:/configured-media/videos/test.mp4").toAbsolutePath().normalize());
+    }
+
+    @Test
+    void resolveErrorMessageReturnsReadableHintWhenFfmpegExecutableMissing() throws Throwable {
+        ReflectionTestUtils.setField(videoComposeService, "ffmpegPath", "C:/ffmpeg/bin/ffmpeg.exe");
+
+        Method method = VideoComposeService.class.getDeclaredMethod("resolveErrorMessage", Throwable.class);
+        method.setAccessible(true);
+        String message = (String) method.invoke(
+            videoComposeService,
+            new IOException("Cannot run program \"ffmpeg\": CreateProcess error=2, 系统找不到指定的文件。")
+        );
+
+        assertThat(message)
+                .contains("未找到 ffmpeg 可执行文件")
+                .contains("video.compose.ffmpeg-path")
+                .contains("C:/ffmpeg/bin/ffmpeg.exe");
+    }
+
+    private Object invokePrivate(String methodName, Object argument) throws Throwable {
+        Method method = VideoComposeService.class.getDeclaredMethod(methodName, argument.getClass());
+        method.setAccessible(true);
+        try {
+            return method.invoke(videoComposeService, argument);
+        } catch (InvocationTargetException e) {
+            throw e.getCause();
+        }
+    }
+}


### PR DESCRIPTION
后端: 新增 VideoComposeService 用 ffmpeg 拼接本集所有镜头视频（concat demuxer 优先零转码，失败回退 filter_complex 重编码）。新增 AsyncConfig 异步线程池 videoComposeExecutor。StoryboardEpisode 新增 4 个字段（composedVideoUrl/composeStatus/composeErrorMsg/composedAt）。新增端点 POST /api/storyboard/episode/{id}/compose-video。Migration V1.0.5.0.2 添加对应数据库列。

前端: 分镜页集级别新增"合成本集视频"按钮（4 个状态：未开始/合成中/已完成/失败）。集成 AI 任务中心：pipeline-store 新增 addSimpleTask/markSimpleTask 支持非 SSE 任务，分镜页提交合成后自动展开通知面板，完成后自动弹出视频预览。轮询间隔 2s，提交后 800ms 触发首次刷新避免错过快速完成的状态。