### PR TITLE
Add Atlas Cloud OpenAI-compatible provider support

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ AI 模型可在系统设置页面动态管理，支持以下提供商：
 | 提供商    | 模型示例                         |
 | --------- | -------------------------------- |
 | OpenAI    | GPT-4o, GPT-4o-mini              |
+| Atlas Cloud | qwen/qwen3.5-flash, deepseek-ai/deepseek-v4-pro |
 | Anthropic | Claude 4 Opus, Claude 4 Sonnet   |
 | Google    | Gemini 2.5 Pro, Gemini 2.5 Flash |
 | 通义千问  | Qwen-Max, Qwen-Plus              |

--- a/ai-fusion-video/src/main/java/com/stonewu/fusion/service/ai/provider/AiProviderContextFactory.java
+++ b/ai-fusion-video/src/main/java/com/stonewu/fusion/service/ai/provider/AiProviderContextFactory.java
@@ -121,6 +121,7 @@ public class AiProviderContextFactory {
             if (url.contains("localhost") || url.contains("127.0.0.1")) return "ollama";
             if (url.contains("ai.google.dev") || url.contains("generativelanguage")) return "gemini";
             if (url.contains("googleapis.com") || url.contains("vertex")) return "vertex_ai";
+            if (url.contains("atlascloud.ai")) return "atlascloud";
             if (url.contains("openai.com")) return "openai_compatible";
             return "openai_compatible";
         }

--- a/ai-fusion-video/src/main/java/com/stonewu/fusion/service/ai/provider/OpenAiCompatibleAiProvider.java
+++ b/ai-fusion-video/src/main/java/com/stonewu/fusion/service/ai/provider/OpenAiCompatibleAiProvider.java
@@ -29,7 +29,7 @@ import java.util.Set;
 public class OpenAiCompatibleAiProvider extends AbstractAiProvider {
 
     private static final Set<String> SUPPORTED_PLATFORMS = Set.of(
-            "openai_compatible", "openai", "deepseek", "zhipu", "moonshot", "volcengine", "siliconflow", "newapi");
+            "openai_compatible", "openai", "atlascloud", "deepseek", "zhipu", "moonshot", "volcengine", "siliconflow", "newapi");
 
     @Override
     public boolean supports(String platform) {
@@ -247,6 +247,7 @@ public class OpenAiCompatibleAiProvider extends AbstractAiProvider {
             case "siliconflow" -> "https://api.siliconflow.cn";
             case "newapi" -> "https://docs.newapi.ai";
             case "openai" -> "https://api.openai.com";
+            case "atlascloud" -> "https://api.atlascloud.ai";
             default -> "https://api.openai.com";
         };
     }

--- a/ai-fusion-video/src/test/java/com/stonewu/fusion/service/ai/provider/AiProviderContextFactoryTests.java
+++ b/ai-fusion-video/src/test/java/com/stonewu/fusion/service/ai/provider/AiProviderContextFactoryTests.java
@@ -8,6 +8,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 class AiProviderContextFactoryTests {
 
     @Test
+    void createForApiConfigDetectsAtlasCloudUrl() {
+        AiProviderContextFactory factory = new AiProviderContextFactory(null);
+
+        AiProviderContext context = factory.createForApiConfig(
+                ApiConfig.builder().apiUrl("https://api.atlascloud.ai/v1").build());
+
+        assertThat(context.getPlatform()).isEqualTo("atlascloud");
+    }
+
+    @Test
     void createForApiConfigNormalizesLegacyOpenAiPlatform() {
         AiProviderContextFactory factory = new AiProviderContextFactory(null);
 

--- a/ai-fusion-video/src/test/java/com/stonewu/fusion/service/ai/provider/OpenAiCompatibleAiProviderTests.java
+++ b/ai-fusion-video/src/test/java/com/stonewu/fusion/service/ai/provider/OpenAiCompatibleAiProviderTests.java
@@ -5,11 +5,30 @@ import io.agentscope.core.model.GenerateOptions;
 import io.agentscope.core.model.Model;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Method;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 class OpenAiCompatibleAiProviderTests {
+
+    @Test
+    void supportsAtlasCloudPlatformWithDefaultV1ChatPath() throws Exception {
+        OpenAiCompatibleAiProvider provider = new OpenAiCompatibleAiProvider();
+
+        assertThat(provider.supports("atlascloud")).isTrue();
+
+        Method inferRootBaseUrl = OpenAiCompatibleAiProvider.class
+                .getDeclaredMethod("inferRootBaseUrl", String.class);
+        inferRootBaseUrl.setAccessible(true);
+        assertThat(inferRootBaseUrl.invoke(provider, "atlascloud")).isEqualTo("https://api.atlascloud.ai");
+
+        Method resolveCompletionsPath = OpenAiCompatibleAiProvider.class
+                .getDeclaredMethod("resolveCompletionsPath", AiProviderContext.class);
+        resolveCompletionsPath.setAccessible(true);
+        AiProviderContext context = AiProviderContext.builder().platform("atlascloud").build();
+        assertThat(resolveCompletionsPath.invoke(provider, context)).isEqualTo("/v1/chat/completions");
+    }
 
     @Test
     void createAgentScopeModelUsesResponsesModelWhenEnabled() {


### PR DESCRIPTION
## Summary
- add Atlas Cloud as a first-class OpenAI-compatible provider platform
- detect `atlascloud.ai` API URLs as `atlascloud`
- document Atlas Cloud in the existing AI provider table
- add focused provider/context tests for Atlas Cloud routing

## Notes
- Atlas Cloud models were checked against the live model list before using `qwen/qwen3.5-flash` and `deepseek-ai/deepseek-v4-pro` as examples.
- No sponsor, logo, credits, or partner placement was added.

## Tests
- Not run locally; the local clone repeatedly timed out, so this patch was created from the upstream tree via the GitHub API.
