### PR TITLE
feat: add delete functionality for image/video generation records

### DIFF
--- a/ai-fusion-video-web/components/dashboard/generation-workbench.tsx
+++ b/ai-fusion-video-web/components/dashboard/generation-workbench.tsx
@@ -269,6 +269,20 @@ export default function GenerationWorkbench({ mode }: GenerationWorkbenchProps) 
     }
   };
 
+  const deleteTask = async (id: number) => {
+    try {
+      if (mode === "image") {
+        await generationApi.deleteImage(id);
+      } else {
+        await generationApi.deleteVideo(id);
+      }
+      toast.success("创作记录已删除");
+      await loadHistory(historyLimit);
+    } catch (error) {
+      toastApiError(error, "删除创作记录失败");
+    }
+  };
+
   useEffect(() => {
     void loadHistory(historyLimit);
   }, [historyLimit, loadHistory]);
@@ -876,6 +890,7 @@ export default function GenerationWorkbench({ mode }: GenerationWorkbenchProps) 
                     onUseReference={useReference}
                     onCancel={taskId => void cancelTask(taskId)}
                     cancellingTaskIds={cancellingTaskIds}
+                    onDelete={id => void deleteTask(id)}
                     onAddAsset={(item, prompt) =>
                       setAssetTarget({ mode, item, prompt })
                     }

--- a/ai-fusion-video-web/components/dashboard/generation/generation-history.tsx
+++ b/ai-fusion-video-web/components/dashboard/generation/generation-history.tsx
@@ -8,7 +8,9 @@ import {
   RotateCcw,
   Square,
   Sparkles,
+  Trash2,
 } from "lucide-react";
+import { useConfirm } from "@/components/ui/confirm-dialog";
 import type { AiModel } from "@/lib/api/ai-model";
 import { getModelDisplayParts } from "@/lib/model-display";
 import { Button } from "@/components/ui/button";
@@ -68,6 +70,7 @@ interface GenerationHistoryProps {
   onAddAsset: (item: GenerationResultItem, prompt: string) => void;
   onCancel: (taskId: string) => void;
   cancellingTaskIds: Set<string>;
+  onDelete: (id: number) => void;
 }
 
 export function GenerationHistory({
@@ -84,9 +87,11 @@ export function GenerationHistory({
   onAddAsset,
   onCancel,
   cancellingTaskIds,
+  onDelete,
 }: GenerationHistoryProps) {
   const [mediaPreview, setMediaPreview] = useState<GenerationMediaPreview | null>(null);
   const modelsById = new Map(models.map((model) => [model.id, model]));
+  const { confirm } = useConfirm();
 
   if (loading && entries.length === 0) {
     return (
@@ -271,6 +276,25 @@ export function GenerationHistory({
                 >
                   <RotateCcw className="h-3 w-3" />
                   再次使用
+                </Button>
+                <Button
+                  variant="destructive-ghost"
+                  size="xs"
+                  onClick={async () => {
+                    const confirmed = await confirm({
+                      title: "删除创作记录",
+                      description: "删除后该任务的生成记录和结果将无法恢复，确定删除吗？",
+                      confirmText: "确定删除",
+                      variant: "destructive",
+                    });
+                    if (confirmed) {
+                      onDelete(task.id);
+                    }
+                  }}
+                  title="删除创作记录"
+                >
+                  <Trash2 className="h-3 w-3" />
+                  删除
                 </Button>
               </div>
             </header>

--- a/ai-fusion-video-web/lib/api/generation.ts
+++ b/ai-fusion-video-web/lib/api/generation.ts
@@ -113,6 +113,8 @@ export const generationApi = {
     ),
   cancelImage: (taskId: string) =>
     http.post<never, boolean>(`/api/generation/image/${encodeURIComponent(taskId)}/cancel`),
+  deleteImage: (id: number) =>
+    http.delete<never, boolean>(`/api/generation/image/${id}`),
 
   submitVideo: (data: VideoGenerationSubmitReq) =>
     http.post<never, string>("/api/generation/video/submit", data),
@@ -126,4 +128,6 @@ export const generationApi = {
     ),
   cancelVideo: (taskId: string) =>
     http.post<never, boolean>(`/api/generation/video/${encodeURIComponent(taskId)}/cancel`),
+  deleteVideo: (id: number) =>
+    http.delete<never, boolean>(`/api/generation/video/${id}`),
 };

--- a/ai-fusion-video/src/main/java/com/stonewu/fusion/config/ai/AiAgentRegistry.java
+++ b/ai-fusion-video/src/main/java/com/stonewu/fusion/config/ai/AiAgentRegistry.java
@@ -100,6 +100,8 @@ public class AiAgentRegistry {
                                                 "delete_storyboard_child_resource",
                                                 "get_generation_model_capabilities",
                                                 "generate_image",
+                                                "delete_image_task",
+                                                "delete_video_task",
                                                 "query_asset_metadata"))
                                 .systemPrompt(loadPrompt("ai-media.system.md"))
                                 .instructionTemplate(loadPrompt("ai-media.instruction.md"))

--- a/ai-fusion-video/src/main/java/com/stonewu/fusion/controller/generation/ImageGenerationController.java
+++ b/ai-fusion-video/src/main/java/com/stonewu/fusion/controller/generation/ImageGenerationController.java
@@ -66,4 +66,12 @@ public class ImageGenerationController {
         return CommonResult.success(imageGenerationConsumer.cancelTask(
                 taskId, requireCurrentUserId()));
     }
+
+    @Operation(summary = "删除图片生成任务")
+    @DeleteMapping("/{id}")
+    public CommonResult<Boolean> deleteImageTask(@PathVariable Long id) {
+        Long userId = requireCurrentUserId();
+        imageGenerationService.delete(id, userId);
+        return CommonResult.success(true);
+    }
 }

--- a/ai-fusion-video/src/main/java/com/stonewu/fusion/controller/generation/VideoGenerationController.java
+++ b/ai-fusion-video/src/main/java/com/stonewu/fusion/controller/generation/VideoGenerationController.java
@@ -66,4 +66,12 @@ public class VideoGenerationController {
         return CommonResult.success(videoGenerationConsumer.cancelTask(
                 taskId, requireCurrentUserId()));
     }
+
+    @Operation(summary = "删除视频生成任务")
+    @DeleteMapping("/{id}")
+    public CommonResult<Boolean> deleteVideoTask(@PathVariable Long id) {
+        Long userId = requireCurrentUserId();
+        videoGenerationService.delete(id, userId);
+        return CommonResult.success(true);
+    }
 }

--- a/ai-fusion-video/src/main/java/com/stonewu/fusion/service/ai/tool/generation/DeleteImageTaskToolExecutor.java
+++ b/ai-fusion-video/src/main/java/com/stonewu/fusion/service/ai/tool/generation/DeleteImageTaskToolExecutor.java
@@ -1,0 +1,71 @@
+package com.stonewu.fusion.service.ai.tool.generation;
+
+import cn.hutool.json.JSONObject;
+import cn.hutool.json.JSONUtil;
+import com.stonewu.fusion.service.ai.ToolExecutionContext;
+import com.stonewu.fusion.service.ai.ToolExecutor;
+import com.stonewu.fusion.service.generation.image.ImageGenerationService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+/** 删除图片生成任务工具。 */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class DeleteImageTaskToolExecutor implements ToolExecutor {
+
+    private final ImageGenerationService imageGenerationService;
+
+    @Override
+    public String getToolName() {
+        return "delete_image_task";
+    }
+
+    @Override
+    public String getDisplayName() {
+        return "删除图片生成任务";
+    }
+
+    @Override
+    public String getToolDescription() {
+        return "删除当前用户的图片生成任务及其生成结果，属于高风险操作。";
+    }
+
+    @Override
+    public String getParametersSchema() {
+        return """
+                {
+                    "type": "object",
+                    "properties": {
+                        "taskId": {"type": "integer", "description": "要删除的图片生成任务ID"}
+                    },
+                    "required": ["taskId"],
+                    "additionalProperties": false
+                }
+                """;
+    }
+
+    @Override
+    public String execute(String toolInput, ToolExecutionContext context) {
+        try {
+            JSONObject params = JSONUtil.parseObj(toolInput);
+            Long taskId = params.getLong("taskId");
+            if (taskId == null) {
+                return error("缺少 taskId");
+            }
+            imageGenerationService.delete(taskId, context.getUserId());
+            return JSONUtil.createObj()
+                    .set("status", "success")
+                    .set("deletedTaskId", taskId)
+                    .toString();
+        } catch (Exception e) {
+            log.error("删除图片生成任务失败", e);
+            return error("删除图片生成任务失败: " + e.getMessage());
+        }
+    }
+
+    private String error(String message) {
+        return JSONUtil.createObj().set("status", "error").set("message", message).toString();
+    }
+}

--- a/ai-fusion-video/src/main/java/com/stonewu/fusion/service/ai/tool/generation/DeleteVideoTaskToolExecutor.java
+++ b/ai-fusion-video/src/main/java/com/stonewu/fusion/service/ai/tool/generation/DeleteVideoTaskToolExecutor.java
@@ -1,0 +1,71 @@
+package com.stonewu.fusion.service.ai.tool.generation;
+
+import cn.hutool.json.JSONObject;
+import cn.hutool.json.JSONUtil;
+import com.stonewu.fusion.service.ai.ToolExecutionContext;
+import com.stonewu.fusion.service.ai.ToolExecutor;
+import com.stonewu.fusion.service.generation.video.VideoGenerationService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+/** 删除视频生成任务工具。 */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class DeleteVideoTaskToolExecutor implements ToolExecutor {
+
+    private final VideoGenerationService videoGenerationService;
+
+    @Override
+    public String getToolName() {
+        return "delete_video_task";
+    }
+
+    @Override
+    public String getDisplayName() {
+        return "删除视频生成任务";
+    }
+
+    @Override
+    public String getToolDescription() {
+        return "删除当前用户的视频生成任务及其生成结果，属于高风险操作。";
+    }
+
+    @Override
+    public String getParametersSchema() {
+        return """
+                {
+                    "type": "object",
+                    "properties": {
+                        "taskId": {"type": "integer", "description": "要删除的视频生成任务ID"}
+                    },
+                    "required": ["taskId"],
+                    "additionalProperties": false
+                }
+                """;
+    }
+
+    @Override
+    public String execute(String toolInput, ToolExecutionContext context) {
+        try {
+            JSONObject params = JSONUtil.parseObj(toolInput);
+            Long taskId = params.getLong("taskId");
+            if (taskId == null) {
+                return error("缺少 taskId");
+            }
+            videoGenerationService.delete(taskId, context.getUserId());
+            return JSONUtil.createObj()
+                    .set("status", "success")
+                    .set("deletedTaskId", taskId)
+                    .toString();
+        } catch (Exception e) {
+            log.error("删除视频生成任务失败", e);
+            return error("删除视频生成任务失败: " + e.getMessage());
+        }
+    }
+
+    private String error(String message) {
+        return JSONUtil.createObj().set("status", "error").set("message", message).toString();
+    }
+}

--- a/ai-fusion-video/src/main/java/com/stonewu/fusion/service/generation/image/ImageGenerationService.java
+++ b/ai-fusion-video/src/main/java/com/stonewu/fusion/service/generation/image/ImageGenerationService.java
@@ -11,6 +11,7 @@ import com.stonewu.fusion.mapper.generation.ImageTaskMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Caching;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -72,9 +73,18 @@ public class ImageGenerationService {
         taskMapper.updateById(task);
     }
 
-    @CacheEvict(value = "imageTask", allEntries = true)
+    @Caching(evict = {
+            @CacheEvict(value = "imageTask", allEntries = true),
+            @CacheEvict(value = "imageItems", allEntries = true)
+    })
     @Transactional
-    public void delete(Long id) {
+    public void delete(Long id, Long userId) {
+        ImageTask task = taskMapper.selectById(id);
+        if (task == null || !task.getUserId().equals(userId)) {
+            return;
+        }
+        // 删除关联的图片条目
+        itemMapper.delete(new LambdaQueryWrapper<ImageItem>().eq(ImageItem::getTaskId, id));
         taskMapper.deleteById(id);
     }
 

--- a/ai-fusion-video/src/main/java/com/stonewu/fusion/service/generation/video/VideoGenerationService.java
+++ b/ai-fusion-video/src/main/java/com/stonewu/fusion/service/generation/video/VideoGenerationService.java
@@ -11,6 +11,7 @@ import com.stonewu.fusion.mapper.generation.VideoTaskMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Caching;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -72,9 +73,18 @@ public class VideoGenerationService {
         taskMapper.updateById(task);
     }
 
-    @CacheEvict(value = "videoTask", allEntries = true)
+    @Caching(evict = {
+            @CacheEvict(value = "videoTask", allEntries = true),
+            @CacheEvict(value = "videoItems", allEntries = true)
+    })
     @Transactional
-    public void delete(Long id) {
+    public void delete(Long id, Long userId) {
+        VideoTask task = taskMapper.selectById(id);
+        if (task == null || !task.getUserId().equals(userId)) {
+            return;
+        }
+        // 删除关联的视频条目
+        itemMapper.delete(new LambdaQueryWrapper<VideoItem>().eq(VideoItem::getTaskId, id));
         taskMapper.deleteById(id);
     }
 


### PR DESCRIPTION
## 变更内容

为图片/视频生成记录添加删除功能，支持用户删除自己的生成任务及结果。

### 后端
- `ImageGenerationController` / `VideoGenerationController`：新增 `DELETE /api/generation/image/{id}`、`DELETE /api/generation/video/{id}` 端点
- `ImageGenerationService` / `VideoGenerationService`：新增 `delete(id, userId)`，包含所有权校验、级联删除生成条目、缓存清理（`@Caching`）
- 新增 AI 工具 `delete_image_task` / `delete_video_task`（`DeleteImageTaskToolExecutor` / `DeleteVideoTaskToolExecutor`，高风险操作）
- `AiAgentRegistry`：将新删除工具分配给 `ai_media` agent

### 前端
- `generation.ts`：新增 `deleteImage` / `deleteVideo` API
- `generation-history.tsx`：新增删除按钮（带二次确认）
- `generation-workbench.tsx`：新增 `deleteTask` 处理并接线

## 验证
- 前端 `tsc --noEmit`、`eslint` 通过
- 后端编译通过，`FlywayMigrationNamingTests` (2/2)、`AiAgentToolRegistrationTests` (7/7) 通过