### PR TITLE
fix(comfyui): 输出媒体类型按扩展名优先，上传图片走 LoadImage 连线

### DIFF
--- a/ai-fusion-video/src/main/java/com/stonewu/fusion/service/ai/comfyui/ComfyUiOutputResolver.java
+++ b/ai-fusion-video/src/main/java/com/stonewu/fusion/service/ai/comfyui/ComfyUiOutputResolver.java
@@ -3,6 +3,7 @@ package com.stonewu.fusion.service.ai.comfyui;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.stonewu.fusion.common.BusinessException;
 import com.stonewu.fusion.service.ai.comfyui.client.ComfyUiJobResult;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
@@ -14,6 +15,7 @@ import java.util.Map;
 import java.util.Set;
 
 /** Resolves only explicitly bound output nodes from a completed ComfyUI job. */
+@Slf4j
 @Component
 public class ComfyUiOutputResolver {
 
@@ -35,7 +37,12 @@ public class ComfyUiOutputResolver {
                 for (JsonNode item : field.getValue()) {
                     if (!item.isObject() || !item.path("filename").isTextual()) continue;
                     String actualMediaType = classify(field.getKey(), item);
-                    if (!matches(binding.mediaType(), actualMediaType)) continue;
+                    if (!matches(binding.mediaType(), actualMediaType)) {
+                        log.debug("ComfyUI output resolve skipped: nodeId={}, outputKey={}, filename={}, expectedMediaType={}, actualMediaType={}",
+                                binding.nodeId(), field.getKey(), item.path("filename").asText(),
+                                binding.mediaType(), actualMediaType);
+                        continue;
+                    }
                     String filename = item.path("filename").asText();
                     JsonNode subfolderNode = item.get("subfolder");
                     JsonNode typeNode = item.get("type");
@@ -68,12 +75,21 @@ public class ComfyUiOutputResolver {
         String key = outputKey.toLowerCase(Locale.ROOT);
         String format = item.path("format").asText("").toLowerCase(Locale.ROOT);
         String filename = item.path("filename").asText("").toLowerCase(Locale.ROOT);
-        if (key.contains("image") || format.startsWith("image/") || hasExtension(filename,
-                "png", "jpg", "jpeg", "webp", "gif")) return "image";
-        if (key.contains("video") || key.equals("gifs") || format.startsWith("video/")
-                || hasExtension(filename, "mp4", "webm", "mov", "mkv")) return "video";
-        if (key.contains("audio") || format.startsWith("audio/")
-                || hasExtension(filename, "mp3", "wav", "flac", "m4a", "ogg")) return "audio";
+
+        // ComfyUI 的输出字段名不可靠：视频常被放在 images 字段下（animated 输出）。
+        // 因此文件扩展名优先级最高，其次 MIME format，最后才是输出字段名。
+        if (hasExtension(filename, "mp4", "webm", "mov", "mkv", "avi", "m4v")) return "video";
+        if (hasExtension(filename, "mp3", "wav", "flac", "m4a", "ogg", "aac")) return "audio";
+        if (hasExtension(filename, "png", "jpg", "jpeg", "webp", "gif", "bmp", "tiff")) return "image";
+
+        if (format.startsWith("video/")) return "video";
+        if (format.startsWith("audio/")) return "audio";
+        if (format.startsWith("image/")) return "image";
+
+        if (key.contains("video") || key.equals("gifs")) return "video";
+        if (key.contains("audio")) return "audio";
+        if (key.contains("image")) return "image";
+
         return "file";
     }
 

--- a/ai-fusion-video/src/main/java/com/stonewu/fusion/service/ai/comfyui/ComfyUiWorkflowRenderer.java
+++ b/ai-fusion-video/src/main/java/com/stonewu/fusion/service/ai/comfyui/ComfyUiWorkflowRenderer.java
@@ -40,9 +40,35 @@ public class ComfyUiWorkflowRenderer {
             Object selectedValue = selectIndexedValue(rawValue, binding);
             JsonNode renderedValue = convertValue(selectedValue, binding);
             ObjectNode node = (ObjectNode) workflow.get(binding.nodeId());
-            ((ObjectNode) node.get("inputs")).set(binding.inputName(), renderedValue);
+            ObjectNode nodeInputs = (ObjectNode) node.get("inputs");
+            JsonNode current = nodeInputs.get(binding.inputName());
+            if (isUploadedMedia(binding.valueType()) && isLink(current)) {
+                // IMAGE 类输入需要张量而非文件名：目标输入当前是连线（如 LoadImage → 节点）时，
+                // 把上传文件名写到连线源节点的 image 输入，由 ComfyUI 加载成张量后经连线传入；
+                // 直接覆盖目标输入会把字符串塞进 IMAGE 输入导致 TypeError。
+                String sourceNodeId = current.get(0).asText();
+                ObjectNode sourceNode = (ObjectNode) workflow.get(sourceNodeId);
+                if (sourceNode != null && sourceNode.path("inputs").isObject()
+                        && sourceNode.path("inputs").has("image")) {
+                    ((ObjectNode) sourceNode.get("inputs")).set("image", renderedValue);
+                    continue;
+                }
+            }
+            nodeInputs.set(binding.inputName(), renderedValue);
         }
         return workflow;
+    }
+
+    private static boolean isUploadedMedia(String valueType) {
+        return "uploaded_image".equals(valueType)
+                || "uploaded_video".equals(valueType)
+                || "uploaded_audio".equals(valueType);
+    }
+
+    /** ComfyUI 连线格式：["源节点ID", 槽位索引]。 */
+    private static boolean isLink(JsonNode value) {
+        return value != null && value.isArray() && value.size() >= 2
+                && value.get(0).isTextual() && value.get(1).isInt();
     }
 
     private Object selectIndexedValue(Object rawValue, ComfyUiInputBinding binding) {


### PR DESCRIPTION
## 问题 1：ComfyUI 视频输出被误判丢弃

### 现象
ComfyUI 工作流执行成功后，平台仍报「ComfyUI 任务已完成，但绑定的输出节点没有返回文件」。

### 复现步骤
1. 配置视频工作流（如 `MiniMaxH3ImageToVideo → SaveVideo`），将输出绑定到保存视频的节点（如 nodeId=`92`），mediaType=`video`。
2. ComfyUI `/history/{prompt_id}` 返回（ComfyUI 将视频放在 `images` 字段下，即 animated 输出）：
   ```json
   {
     "outputs": {
       "92": {
         "images": [{ "filename": "MiniMax_H3_00001_.mp4", "subfolder": "", "type": "output" }]
       }
     },
     "status": { "status_str": "success", "completed": true }
   }
   ```
3. 运行生成 → 平台报「绑定的输出节点没有返回文件」；但 `GET /view?filename=MiniMax_H3_00001_.mp4&subfolder=&type=output` 实际返回 200，可正常下载视频。

### 根因
`ComfyUiOutputResolver.classify()` 优先按输出字段名判断：字段名 `images` 包含 `image` → 判定为 `image`，而绑定要求 `video` → `matches()` 失败 → 输出被全部丢弃。ComfyUI 的字段名（`images`）无法可靠代表媒体类型。

### 修复
`classify()` 判定优先级改为：**文件扩展名 → MIME format → 输出字段名**。`xxx.mp4` 直接判定为 `video`，不再被字段名误导。

---

## 问题 2：上传首帧/尾帧图片导致 ComfyUI TypeError

### 现象
带 firstFrame/lastFrame 的图生视频任务失败，ComfyUI 执行报：

```
TypeError: string indices must be integers, not 'tuple'
```

traceback 指向 `comfy_extras/nodes_minimax_h3.py`：

```python
img = _resize(first_frame[:1], width, height, "disabled")   # line 132
samples = image[..., :3].movedim(-1, 1)                     # line 65
```

`/history` 的 `current_inputs` 中 `first_frame` 为字符串（`"ai-fusion-video/xxx-firstFrame-0.png"`）而非张量。

### 复现步骤
1. 工作流中视频节点的 `first_frame` / `last_frame` 输入由 LoadImage 节点连线提供（类型 IMAGE，需要张量）。
2. 平台输入绑定将 `firstFrame` 绑到该节点输入，valueType=`uploaded_image`。
3. 渲染器把上传后的文件名字符串**直接写入目标节点的输入**，覆盖了原有连线 → 字符串进入 IMAGE 类型输入 → 节点把字符串当图片切片 → TypeError。

### 修复
`ComfyUiWorkflowRenderer`：上传媒体绑定（`uploaded_image` / `uploaded_video` / `uploaded_audio`）若目标输入当前是连线（格式 `["源节点ID", 槽位索引]`），将上传文件名写入**连线源节点（LoadImage）的 `image` 输入**，由 ComfyUI 加载成张量后经连线传入；仅当目标输入不是连线时才直接写入目标输入。

---

## 验证
- 问题 1：视频工作流测试通过，输出被正确识别为 `video` 并正常入库。
- 问题 2：带首帧 + 尾帧的生成任务不再报 TypeError，视频正常生成。
